### PR TITLE
feat: seamless local model setup with auto-install, pull, and first-run wizard

### DIFF
--- a/cmd/ratchet/cmd_model.go
+++ b/cmd/ratchet/cmd_model.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	wfprovider "github.com/GoCodeAlone/workflow-plugin-agent/provider"
+)
+
+func handleModel(args []string) {
+	if len(args) == 0 {
+		fmt.Println("Usage: ratchet model <list|pull>")
+		fmt.Println()
+		fmt.Println("Commands:")
+		fmt.Println("  list                              List installed Ollama models")
+		fmt.Println("  pull <name>                       Pull a model via Ollama")
+		fmt.Println("  pull --from huggingface <repo> <file>  Download GGUF from HuggingFace")
+		return
+	}
+
+	switch args[0] {
+	case "list":
+		handleModelList()
+	case "pull":
+		handleModelPull(args[1:])
+	default:
+		fmt.Printf("unknown model command: %s\n", args[0])
+		fmt.Println("Usage: ratchet model <list|pull>")
+	}
+}
+
+func handleModelList() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	c := wfprovider.NewOllamaClient("")
+	models, err := c.ListModels(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error listing models: %v\n", err)
+		fmt.Fprintln(os.Stderr, "Is Ollama running? Try: ollama serve")
+		os.Exit(1)
+	}
+	if len(models) == 0 {
+		fmt.Println("No models installed.")
+		fmt.Println("Pull one with: ratchet model pull qwen3:8b")
+		return
+	}
+	fmt.Printf("%-40s %s\n", "NAME", "CONTEXT")
+	for _, m := range models {
+		ctx := ""
+		if m.ContextWindow > 0 {
+			ctx = fmt.Sprintf("%d", m.ContextWindow)
+		}
+		fmt.Printf("%-40s %s\n", m.Name, ctx)
+	}
+}
+
+func handleModelPull(args []string) {
+	// Check for --from huggingface flag
+	if len(args) >= 3 && args[0] == "--from" && args[1] == "huggingface" {
+		repo := args[2]
+		if len(args) < 4 {
+			fmt.Fprintln(os.Stderr, "Usage: ratchet model pull --from huggingface <repo> <file>")
+			os.Exit(1)
+		}
+		file := args[3]
+		handleHuggingFacePull(repo, file)
+		return
+	}
+
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "Usage: ratchet model pull <name>")
+		fmt.Fprintln(os.Stderr, "       ratchet model pull --from huggingface <repo> <file>")
+		os.Exit(1)
+	}
+
+	name := args[0]
+	ctx := context.Background()
+	c := wfprovider.NewOllamaClient("")
+
+	fmt.Printf("Pulling %s...\n", name)
+	if err := pullModelWithProgress(ctx, c, name); err != nil {
+		fmt.Fprintf(os.Stderr, "\npull failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("\n✓ %s ready\n", name)
+}
+
+func handleHuggingFacePull(repo, file string) {
+	ctx := context.Background()
+	fmt.Printf("Downloading %s/%s from HuggingFace...\n", repo, file)
+	lastPct := -1.0
+	path, err := wfprovider.DownloadHuggingFaceFile(ctx, repo, file, "", func(pct float64) {
+		if pct-lastPct >= 5.0 || pct >= 100.0 {
+			fmt.Printf("\r  %.0f%%", pct)
+			lastPct = pct
+		}
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\ndownload failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("\n✓ Saved to: %s\n", path)
+}

--- a/cmd/ratchet/cmd_model.go
+++ b/cmd/ratchet/cmd_model.go
@@ -20,32 +20,36 @@ func handleModel(args []string) {
 		return
 	}
 
+	var err error
 	switch args[0] {
 	case "list":
-		handleModelList()
+		err = handleModelList()
 	case "pull":
-		handleModelPull(args[1:])
+		err = handleModelPull(args[1:])
 	default:
 		fmt.Printf("unknown model command: %s\n", args[0])
 		fmt.Println("Usage: ratchet model <list|pull>")
+		return
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
 	}
 }
 
-func handleModelList() {
+func handleModelList() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	c := wfprovider.NewOllamaClient("")
 	models, err := c.ListModels(ctx)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error listing models: %v\n", err)
-		fmt.Fprintln(os.Stderr, "Is Ollama running? Try: ollama serve")
-		os.Exit(1)
+		return fmt.Errorf("listing models: %w\nIs Ollama running? Try: ollama serve", err)
 	}
 	if len(models) == 0 {
 		fmt.Println("No models installed.")
 		fmt.Println("Pull one with: ratchet model pull qwen3:8b")
-		return
+		return nil
 	}
 	fmt.Printf("%-40s %s\n", "NAME", "CONTEXT")
 	for _, m := range models {
@@ -55,25 +59,22 @@ func handleModelList() {
 		}
 		fmt.Printf("%-40s %s\n", m.Name, ctx)
 	}
+	return nil
 }
 
-func handleModelPull(args []string) {
+func handleModelPull(args []string) error {
 	// Check for --from huggingface flag
 	if len(args) >= 3 && args[0] == "--from" && args[1] == "huggingface" {
 		repo := args[2]
 		if len(args) < 4 {
-			fmt.Fprintln(os.Stderr, "Usage: ratchet model pull --from huggingface <repo> <file>")
-			os.Exit(1)
+			return fmt.Errorf("usage: ratchet model pull --from huggingface <repo> <file>")
 		}
 		file := args[3]
-		handleHuggingFacePull(repo, file)
-		return
+		return handleHuggingFacePull(repo, file)
 	}
 
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "Usage: ratchet model pull <name>")
-		fmt.Fprintln(os.Stderr, "       ratchet model pull --from huggingface <repo> <file>")
-		os.Exit(1)
+		return fmt.Errorf("usage: ratchet model pull <name>\n       ratchet model pull --from huggingface <repo> <file>")
 	}
 
 	name := args[0]
@@ -82,13 +83,13 @@ func handleModelPull(args []string) {
 
 	fmt.Printf("Pulling %s...\n", name)
 	if err := pullModelWithProgress(ctx, c, name); err != nil {
-		fmt.Fprintf(os.Stderr, "\npull failed: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("pull %s: %w", name, err)
 	}
-	fmt.Printf("\n✓ %s ready\n", name)
+	fmt.Printf("✓ %s ready\n", name)
+	return nil
 }
 
-func handleHuggingFacePull(repo, file string) {
+func handleHuggingFacePull(repo, file string) error {
 	ctx := context.Background()
 	fmt.Printf("Downloading %s/%s from HuggingFace...\n", repo, file)
 	lastPct := -1.0
@@ -98,9 +99,12 @@ func handleHuggingFacePull(repo, file string) {
 			lastPct = pct
 		}
 	})
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "\ndownload failed: %v\n", err)
-		os.Exit(1)
+	if lastPct >= 0.0 {
+		fmt.Println()
 	}
-	fmt.Printf("\n✓ Saved to: %s\n", path)
+	if err != nil {
+		return fmt.Errorf("download %s/%s: %w", repo, file, err)
+	}
+	fmt.Printf("✓ Saved to: %s\n", path)
+	return nil
 }

--- a/cmd/ratchet/cmd_model_test.go
+++ b/cmd/ratchet/cmd_model_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestHandleModel_NoArgs(t *testing.T) {
+	// handleModel with no args should print usage without panicking.
+	// Redirect stdout to discard output.
+	oldStdout := os.Stdout
+	devNull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = devNull
+	defer func() {
+		os.Stdout = oldStdout
+		devNull.Close()
+	}()
+
+	// Should not panic
+	handleModel([]string{})
+}
+
+func TestHandleModel_UnknownSubcommand(t *testing.T) {
+	oldStdout := os.Stdout
+	devNull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = devNull
+	defer func() {
+		os.Stdout = oldStdout
+		devNull.Close()
+	}()
+
+	// Should not panic for unknown subcommand
+	handleModel([]string{"unknown"})
+}
+
+func TestHandleModel_Pull_MissingName(t *testing.T) {
+	// handleModelPull with no args should exit — we test it doesn't panic before
+	// the os.Exit by checking argument validation indirectly.
+	// The function validates len(args) == 0 and calls os.Exit(1).
+	// We verify the validation logic by checking args parsing.
+	args := []string{}
+	if len(args) == 0 {
+		// Expected: usage message + os.Exit(1)
+		// We don't call the function here as it would exit the test process.
+		// This test documents the expected behavior.
+		return
+	}
+	t.Error("expected early return for missing name")
+}
+
+func TestHandleModel_List_NoServer(t *testing.T) {
+	// handleModelList calls OllamaClient.ListModels which requires a running server.
+	// When Ollama is not running, the function calls os.Exit(1).
+	// We test this by verifying the function exists and the expected behavior
+	// is documented here; integration testing requires a live Ollama instance.
+	_ = handleModelList // ensure it compiles
+}

--- a/cmd/ratchet/cmd_model_test.go
+++ b/cmd/ratchet/cmd_model_test.go
@@ -28,15 +28,39 @@ func TestHandleModel_UnknownSubcommand(t *testing.T) {
 	}
 }
 
-func TestHandleModel_Pull_NoArgs(t *testing.T) {
-	// handleModelPull with no args calls os.Exit(1).
-	// To properly unit-test this, handleModelPull would need to return an error
-	// instead of calling os.Exit. This is a known limitation documented here.
-	// The argument validation is: len(args) == 0 → print usage + exit.
-	// Integration testing with a subprocess would be needed for full coverage.
+func TestHandleModelPull_NoArgs(t *testing.T) {
+	err := handleModelPull([]string{})
+	if err == nil {
+		t.Fatal("expected error for missing model name")
+	}
+	if !strings.Contains(err.Error(), "usage:") {
+		t.Errorf("expected usage error, got: %v", err)
+	}
+}
+
+func TestHandleModelPull_HuggingFace_MissingFile(t *testing.T) {
+	err := handleModelPull([]string{"--from", "huggingface", "org/repo"})
+	if err == nil {
+		t.Fatal("expected error for missing file argument")
+	}
+	if !strings.Contains(err.Error(), "usage:") {
+		t.Errorf("expected usage error, got: %v", err)
+	}
+}
+
+func TestHandleModelList_NoServer(t *testing.T) {
+	// ListModels will fail because Ollama is not running in CI.
+	err := handleModelList()
+	if err == nil {
+		t.Skip("Ollama appears to be running; skipping no-server test")
+	}
+	if !strings.Contains(err.Error(), "listing models") {
+		t.Errorf("expected listing error, got: %v", err)
+	}
 }
 
 // captureStdout redirects os.Stdout to a buffer and returns the captured output.
+// Uses defers to safely restore os.Stdout even if fn panics.
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 	r, w, err := os.Pipe()
@@ -45,12 +69,14 @@ func captureStdout(t *testing.T, fn func()) string {
 	}
 	old := os.Stdout
 	os.Stdout = w
+	defer func() {
+		os.Stdout = old
+		r.Close()
+	}()
 
 	fn()
 
 	w.Close()
-	os.Stdout = old
-
 	var buf bytes.Buffer
 	buf.ReadFrom(r)
 	return buf.String()

--- a/cmd/ratchet/cmd_model_test.go
+++ b/cmd/ratchet/cmd_model_test.go
@@ -14,6 +14,9 @@ func TestHandleModel_NoArgs(t *testing.T) {
 	if !strings.Contains(out, "Usage: ratchet model") {
 		t.Errorf("expected usage message, got: %s", out)
 	}
+	if !strings.Contains(out, "list") || !strings.Contains(out, "pull") {
+		t.Errorf("expected list and pull in usage, got: %s", out)
+	}
 }
 
 func TestHandleModel_UnknownSubcommand(t *testing.T) {
@@ -25,16 +28,12 @@ func TestHandleModel_UnknownSubcommand(t *testing.T) {
 	}
 }
 
-func TestHandleModel_Pull_NoArgs_PrintsUsage(t *testing.T) {
-	// handleModelPull with no args calls os.Exit(1), which we can't test directly.
-	// Verify the argument validation logic: empty args triggers the usage path.
-	args := []string{}
-	if len(args) != 0 {
-		t.Fatal("expected empty args for this test")
-	}
-	// The actual function calls os.Exit — to fully test this, refactor
-	// handleModelPull to return an error instead of calling os.Exit.
-	// For now we document the expected behavior.
+func TestHandleModel_Pull_NoArgs(t *testing.T) {
+	// handleModelPull with no args calls os.Exit(1).
+	// To properly unit-test this, handleModelPull would need to return an error
+	// instead of calling os.Exit. This is a known limitation documented here.
+	// The argument validation is: len(args) == 0 → print usage + exit.
+	// Integration testing with a subprocess would be needed for full coverage.
 }
 
 // captureStdout redirects os.Stdout to a buffer and returns the captured output.

--- a/cmd/ratchet/cmd_model_test.go
+++ b/cmd/ratchet/cmd_model_test.go
@@ -1,63 +1,58 @@
 package main
 
 import (
+	"bytes"
 	"os"
+	"strings"
 	"testing"
 )
 
 func TestHandleModel_NoArgs(t *testing.T) {
-	// handleModel with no args should print usage without panicking.
-	// Redirect stdout to discard output.
-	oldStdout := os.Stdout
-	devNull, err := os.Open(os.DevNull)
-	if err != nil {
-		t.Fatal(err)
+	out := captureStdout(t, func() {
+		handleModel([]string{})
+	})
+	if !strings.Contains(out, "Usage: ratchet model") {
+		t.Errorf("expected usage message, got: %s", out)
 	}
-	os.Stdout = devNull
-	defer func() {
-		os.Stdout = oldStdout
-		devNull.Close()
-	}()
-
-	// Should not panic
-	handleModel([]string{})
 }
 
 func TestHandleModel_UnknownSubcommand(t *testing.T) {
-	oldStdout := os.Stdout
-	devNull, err := os.Open(os.DevNull)
+	out := captureStdout(t, func() {
+		handleModel([]string{"unknown"})
+	})
+	if !strings.Contains(out, "unknown model command: unknown") {
+		t.Errorf("expected unknown command message, got: %s", out)
+	}
+}
+
+func TestHandleModel_Pull_NoArgs_PrintsUsage(t *testing.T) {
+	// handleModelPull with no args calls os.Exit(1), which we can't test directly.
+	// Verify the argument validation logic: empty args triggers the usage path.
+	args := []string{}
+	if len(args) != 0 {
+		t.Fatal("expected empty args for this test")
+	}
+	// The actual function calls os.Exit — to fully test this, refactor
+	// handleModelPull to return an error instead of calling os.Exit.
+	// For now we document the expected behavior.
+}
+
+// captureStdout redirects os.Stdout to a buffer and returns the captured output.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatal(err)
 	}
-	os.Stdout = devNull
-	defer func() {
-		os.Stdout = oldStdout
-		devNull.Close()
-	}()
+	old := os.Stdout
+	os.Stdout = w
 
-	// Should not panic for unknown subcommand
-	handleModel([]string{"unknown"})
-}
+	fn()
 
-func TestHandleModel_Pull_MissingName(t *testing.T) {
-	// handleModelPull with no args should exit — we test it doesn't panic before
-	// the os.Exit by checking argument validation indirectly.
-	// The function validates len(args) == 0 and calls os.Exit(1).
-	// We verify the validation logic by checking args parsing.
-	args := []string{}
-	if len(args) == 0 {
-		// Expected: usage message + os.Exit(1)
-		// We don't call the function here as it would exit the test process.
-		// This test documents the expected behavior.
-		return
-	}
-	t.Error("expected early return for missing name")
-}
+	w.Close()
+	os.Stdout = old
 
-func TestHandleModel_List_NoServer(t *testing.T) {
-	// handleModelList calls OllamaClient.ListModels which requires a running server.
-	// When Ollama is not running, the function calls os.Exit(1).
-	// We test this by verifying the function exists and the expected behavior
-	// is documented here; integration testing requires a live Ollama instance.
-	_ = handleModelList // ensure it compiles
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	return buf.String()
 }

--- a/cmd/ratchet/cmd_provider.go
+++ b/cmd/ratchet/cmd_provider.go
@@ -162,13 +162,16 @@ func handleOllamaSetup(args []string) {
 		}
 	}
 
+	// Single scanner shared across all stdin reads in this command.
+	scanner := bufio.NewScanner(os.Stdin)
+
 	fmt.Println("=== Ollama Setup ===")
 
 	// 1. Check if ollama binary exists.
 	ollamaPath, err := exec.LookPath("ollama")
 	if err != nil {
 		fmt.Println("✗ ollama not found in PATH")
-		if promptYesNo("Ollama not found. Install it?") {
+		if promptYesNo("Ollama not found. Install it?", scanner) {
 			if err := installOllama(); err != nil {
 				fmt.Fprintf(os.Stderr, "install failed: %v\n", err)
 				fmt.Println("Manual install: https://ollama.com/download")
@@ -212,8 +215,8 @@ func handleOllamaSetup(args []string) {
 			fmt.Printf("  %d. %s\n", i+1, m.Name)
 		}
 		fmt.Println()
-		if !promptYesNo("Pull a new model?") {
-			model = promptModelSelection(models)
+		if !promptYesNo("Pull a new model?", scanner) {
+			model = promptModelSelection(models, scanner)
 			wantNew = false
 		}
 	}
@@ -231,7 +234,6 @@ func handleOllamaSetup(args []string) {
 		}
 		fmt.Printf("  %d. Custom (enter name)\n", len(recommended)+1)
 		fmt.Print("\nSelect [1]: ")
-		scanner := bufio.NewScanner(os.Stdin)
 		scanner.Scan()
 		choice := strings.TrimSpace(scanner.Text())
 		switch choice {
@@ -243,7 +245,7 @@ func handleOllamaSetup(args []string) {
 			model = recommended[2].ID
 		default:
 			fmt.Print("Model name: ")
-			scanner.Scan()
+			scanner.Scan() //nolint:staticcheck
 			model = strings.TrimSpace(scanner.Text())
 			if model == "" {
 				model = recommended[0].ID
@@ -300,9 +302,9 @@ func handleOllamaSetup(args []string) {
 }
 
 // promptYesNo prints question + " [Y/n] " and returns true for yes (default).
-func promptYesNo(question string) bool {
+// The caller must pass the shared scanner for the current command.
+func promptYesNo(question string, scanner *bufio.Scanner) bool {
 	fmt.Printf("%s [Y/n] ", question)
-	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Scan()
 	ans := strings.TrimSpace(strings.ToLower(scanner.Text()))
 	return ans == "" || ans == "y" || ans == "yes"
@@ -356,13 +358,13 @@ func pullModelWithProgress(ctx context.Context, c *wfprovider.OllamaClient, mode
 }
 
 // promptModelSelection prints a numbered list of models and returns the selected model ID.
-func promptModelSelection(models []wfprovider.ModelInfo) string {
+// The caller must pass the shared scanner for the current command.
+func promptModelSelection(models []wfprovider.ModelInfo, scanner *bufio.Scanner) string {
 	fmt.Println("Select model:")
 	for i, m := range models {
 		fmt.Printf("  %d. %s\n", i+1, m.Name)
 	}
 	fmt.Print("Select [1]: ")
-	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Scan()
 	choice := strings.TrimSpace(scanner.Text())
 	if choice == "" {

--- a/cmd/ratchet/cmd_provider.go
+++ b/cmd/ratchet/cmd_provider.go
@@ -1,16 +1,19 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"fmt"
-	"net/http"
 	"os"
 	"os/exec"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/GoCodeAlone/ratchet-cli/internal/client"
 	pb "github.com/GoCodeAlone/ratchet-cli/internal/proto"
 	providerauth "github.com/GoCodeAlone/ratchet-cli/internal/provider"
+	wfprovider "github.com/GoCodeAlone/workflow-plugin-agent/provider"
 )
 
 func handleProvider(args []string) {
@@ -164,46 +167,211 @@ func handleOllamaSetup(args []string) {
 	// 1. Check if ollama binary exists.
 	ollamaPath, err := exec.LookPath("ollama")
 	if err != nil {
-		fmt.Println("✗ ollama binary not found in PATH")
-		fmt.Println()
-		fmt.Println("Install Ollama:")
-		fmt.Println("  curl -fsSL https://ollama.com/install.sh | sh")
-		fmt.Println()
-		fmt.Println("Then re-run: ratchet provider setup ollama")
-		return
+		fmt.Println("✗ ollama not found in PATH")
+		if promptYesNo("Ollama not found. Install it?") {
+			if err := installOllama(); err != nil {
+				fmt.Fprintf(os.Stderr, "install failed: %v\n", err)
+				fmt.Println("Manual install: https://ollama.com/download")
+				return
+			}
+			fmt.Println("✓ Ollama installed")
+		} else {
+			fmt.Println("Install Ollama at: https://ollama.com/download")
+			fmt.Println("Then re-run: ratchet provider setup ollama")
+			return
+		}
+	} else {
+		fmt.Printf("✓ ollama found: %s\n", ollamaPath)
 	}
-	fmt.Printf("✓ ollama found: %s\n", ollamaPath)
 
-	// 2. Check if ollama server is running.
-	fmt.Print("  Checking if Ollama server is running... ")
-	httpClient := &http.Client{Timeout: 3 * time.Second}
-	resp, err := httpClient.Get("http://localhost:11434/api/tags")
+	// 2. Check server health; start if needed.
+	ctx := context.Background()
+	ollamaClient := wfprovider.NewOllamaClient("")
+	if err := ollamaClient.Health(ctx); err != nil {
+		fmt.Println("  Ollama server not running — starting it...")
+		if err := startOllamaServer(); err != nil {
+			fmt.Fprintf(os.Stderr, "could not start ollama: %v\n", err)
+			fmt.Println("Start manually: ollama serve")
+			return
+		}
+		fmt.Println("✓ Ollama server started")
+	} else {
+		fmt.Println("✓ Ollama server running")
+	}
+
+	// 3. List installed models.
+	models, err := ollamaClient.ListModels(ctx)
 	if err != nil {
-		fmt.Println("not running")
-		fmt.Println()
-		fmt.Println("Start the Ollama server:")
-		fmt.Println("  ollama serve")
-		fmt.Println()
-		fmt.Println("Then re-run: ratchet provider setup ollama")
-		return
+		fmt.Fprintf(os.Stderr, "could not list models: %v\n", err)
 	}
-	resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		fmt.Printf("not running (HTTP %d)\n", resp.StatusCode)
-		fmt.Println()
-		fmt.Println("Start the Ollama server:")
-		fmt.Println("  ollama serve")
-		fmt.Println()
-		fmt.Println("Then re-run: ratchet provider setup ollama")
-		return
-	}
-	fmt.Println("running ✓")
 
-	// 3. Suggest model to pull.
-	fmt.Printf("\nRecommended model: %s\n", model)
-	fmt.Println()
-	fmt.Println("Next steps:")
-	fmt.Printf("  1. Pull the model:   ollama pull %s\n", model)
-	fmt.Printf("  2. Add to ratchet:   ratchet provider add ollama local-qwen\n")
-	fmt.Printf("  3. Test connection:  ratchet provider test local-qwen\n")
+	wantNew := true
+	if len(models) > 0 {
+		fmt.Println("\nInstalled models:")
+		for i, m := range models {
+			fmt.Printf("  %d. %s\n", i+1, m.Name)
+		}
+		fmt.Println()
+		if !promptYesNo("Pull a new model?") {
+			model = promptModelSelection(models)
+			wantNew = false
+		}
+	}
+
+	// 4. Pull model if needed.
+	if wantNew {
+		recommended := []wfprovider.ModelInfo{
+			{ID: "qwen3:8b", Name: "qwen3:8b      (8GB, fast, good tool use)"},
+			{ID: "llama3.3:8b", Name: "llama3.3:8b   (8GB, general purpose)"},
+			{ID: "gemma3:4b", Name: "gemma3:4b     (4GB, lightweight)"},
+		}
+		fmt.Println("Recommended models:")
+		for i, m := range recommended {
+			fmt.Printf("  %d. %s\n", i+1, m.Name)
+		}
+		fmt.Printf("  %d. Custom (enter name)\n", len(recommended)+1)
+		fmt.Print("\nSelect [1]: ")
+		scanner := bufio.NewScanner(os.Stdin)
+		scanner.Scan()
+		choice := strings.TrimSpace(scanner.Text())
+		switch choice {
+		case "", "1":
+			model = recommended[0].ID
+		case "2":
+			model = recommended[1].ID
+		case "3":
+			model = recommended[2].ID
+		default:
+			fmt.Print("Model name: ")
+			scanner.Scan()
+			model = strings.TrimSpace(scanner.Text())
+			if model == "" {
+				model = recommended[0].ID
+			}
+		}
+
+		fmt.Printf("\nPulling %s...\n", model)
+		if err := pullModelWithProgress(ctx, ollamaClient, model); err != nil {
+			fmt.Fprintf(os.Stderr, "pull failed: %v\n", err)
+			return
+		}
+		fmt.Printf("✓ %s ready\n", model)
+	}
+
+	// 5. Ensure daemon running and register provider.
+	fmt.Println("\nRegistering provider with ratchet...")
+	c, err := client.EnsureDaemon()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "daemon error: %v\n", err)
+		os.Exit(1)
+	}
+	defer func() { _ = c.Close() }()
+
+	p, err := c.AddProvider(ctx, &pb.AddProviderReq{
+		Alias:     "ollama",
+		Type:      "ollama",
+		Model:     model,
+		BaseUrl:   "http://localhost:11434",
+		IsDefault: true,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "add provider failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("✓ Provider registered: %s (%s)\n", p.Alias, p.Type)
+
+	// 6. Test connection.
+	fmt.Print("Testing connection... ")
+	result, err := c.TestProvider(ctx, "ollama")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "test failed: %v\n", err)
+		return
+	}
+	if result.Success {
+		fmt.Printf("OK (%dms)\n", result.LatencyMs)
+	} else {
+		fmt.Printf("FAIL: %s\n", result.Message)
+		return
+	}
+
+	fmt.Println("\n=== Setup complete ===")
+	fmt.Printf("Provider: ollama  Model: %s\n", model)
+	fmt.Println("Run 'ratchet' to start chatting.")
+}
+
+// promptYesNo prints question + " [Y/n] " and returns true for yes (default).
+func promptYesNo(question string) bool {
+	fmt.Printf("%s [Y/n] ", question)
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Scan()
+	ans := strings.TrimSpace(strings.ToLower(scanner.Text()))
+	return ans == "" || ans == "y" || ans == "yes"
+}
+
+// installOllama installs Ollama using the platform-appropriate method.
+func installOllama() error {
+	var cmd *exec.Cmd
+	if runtime.GOOS == "darwin" {
+		cmd = exec.Command("brew", "install", "ollama")
+	} else {
+		cmd = exec.Command("sh", "-c", "curl -fsSL https://ollama.com/install.sh | sh")
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// startOllamaServer starts ollama serve in the background and waits up to 15s for it to be healthy.
+func startOllamaServer() error {
+	cmd := exec.Command("ollama", "serve")
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start ollama serve: %w", err)
+	}
+
+	c := wfprovider.NewOllamaClient("")
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		err := c.Health(ctx)
+		cancel()
+		if err == nil {
+			return nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return fmt.Errorf("ollama server did not become ready within 15s")
+}
+
+// pullModelWithProgress pulls a model via Ollama and prints progress to stdout.
+func pullModelWithProgress(ctx context.Context, c *wfprovider.OllamaClient, model string) error {
+	lastPct := -1.0
+	return c.Pull(ctx, model, func(pct float64) {
+		if pct-lastPct >= 5.0 || pct >= 100.0 {
+			fmt.Printf("\r  %.0f%%", pct)
+			lastPct = pct
+		}
+	})
+}
+
+// promptModelSelection prints a numbered list of models and returns the selected model ID.
+func promptModelSelection(models []wfprovider.ModelInfo) string {
+	fmt.Println("Select model:")
+	for i, m := range models {
+		fmt.Printf("  %d. %s\n", i+1, m.Name)
+	}
+	fmt.Print("Select [1]: ")
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Scan()
+	choice := strings.TrimSpace(scanner.Text())
+	if choice == "" {
+		return models[0].ID
+	}
+	for i := range models {
+		if choice == fmt.Sprintf("%d", i+1) {
+			return models[i].ID
+		}
+	}
+	return models[0].ID
 }

--- a/cmd/ratchet/cmd_provider.go
+++ b/cmd/ratchet/cmd_provider.go
@@ -248,10 +248,14 @@ func handleOllamaSetup(args []string) {
 			model = recommended[2].ID
 		default:
 			fmt.Print("Model name: ")
-			scanner.Scan() //nolint:staticcheck
-			model = strings.TrimSpace(scanner.Text())
-			if model == "" {
+			if !scanner.Scan() {
+				fmt.Fprintln(os.Stderr, "\nNo input received; using default model.")
 				model = recommended[0].ID
+			} else {
+				model = strings.TrimSpace(scanner.Text())
+				if model == "" {
+					model = recommended[0].ID
+				}
 			}
 		}
 
@@ -320,17 +324,28 @@ func promptYesNo(question string, scanner *bufio.Scanner) bool {
 	return ans == "" || ans == "y" || ans == "yes"
 }
 
-// installOllama installs Ollama using the platform-appropriate method.
-func installOllama() error {
-	var cmd *exec.Cmd
+// ollamaInstallCommand returns the exec.Cmd for installing Ollama on the current platform.
+// Returns an error for unsupported platforms.
+func ollamaInstallCommand() (*exec.Cmd, error) {
 	switch runtime.GOOS {
 	case "darwin":
-		cmd = exec.Command("brew", "install", "ollama")
+		return exec.Command("brew", "install", "ollama"), nil
 	case "linux":
-		cmd = exec.Command("sh", "-c", "curl -fsSL https://ollama.com/install.sh | sh")
+		// Download to temp file and execute explicitly (safer than curl|sh).
+		script := `set -e; t=$(mktemp); curl -fsSL https://ollama.com/install.sh -o "$t"; sh "$t"; rm -f "$t"`
+		return exec.Command("sh", "-c", script), nil
 	default:
-		return fmt.Errorf("automatic Ollama installation is not supported on %s; please install manually from https://ollama.com/download", runtime.GOOS)
+		return nil, fmt.Errorf("automatic Ollama installation is not supported on %s; please install manually from https://ollama.com/download", runtime.GOOS)
 	}
+}
+
+// installOllama installs Ollama using the platform-appropriate method.
+func installOllama() error {
+	cmd, err := ollamaInstallCommand()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Running: %s\n", strings.Join(cmd.Args, " "))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/cmd/ratchet/cmd_provider.go
+++ b/cmd/ratchet/cmd_provider.go
@@ -313,10 +313,13 @@ func promptYesNo(question string, scanner *bufio.Scanner) bool {
 // installOllama installs Ollama using the platform-appropriate method.
 func installOllama() error {
 	var cmd *exec.Cmd
-	if runtime.GOOS == "darwin" {
+	switch runtime.GOOS {
+	case "darwin":
 		cmd = exec.Command("brew", "install", "ollama")
-	} else {
+	case "linux":
 		cmd = exec.Command("sh", "-c", "curl -fsSL https://ollama.com/install.sh | sh")
+	default:
+		return fmt.Errorf("automatic Ollama installation is not supported on %s; please install manually from https://ollama.com/download", runtime.GOOS)
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -349,12 +352,16 @@ func startOllamaServer() error {
 // pullModelWithProgress pulls a model via Ollama and prints progress to stdout.
 func pullModelWithProgress(ctx context.Context, c *wfprovider.OllamaClient, model string) error {
 	lastPct := -1.0
-	return c.Pull(ctx, model, func(pct float64) {
+	err := c.Pull(ctx, model, func(pct float64) {
 		if pct-lastPct >= 5.0 || pct >= 100.0 {
 			fmt.Printf("\r  %.0f%%", pct)
 			lastPct = pct
 		}
 	})
+	if lastPct >= 0.0 {
+		fmt.Println() // newline after progress output
+	}
+	return err
 }
 
 // promptModelSelection prints a numbered list of models and returns the selected model ID.

--- a/cmd/ratchet/cmd_provider.go
+++ b/cmd/ratchet/cmd_provider.go
@@ -206,6 +206,9 @@ func handleOllamaSetup(args []string) {
 	models, err := ollamaClient.ListModels(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "could not list models: %v\n", err)
+		fmt.Println("Cannot continue setup until the Ollama server is reachable.")
+		fmt.Println("Please verify Ollama is running, then re-run: ratchet provider setup ollama")
+		return
 	}
 
 	wantNew := true
@@ -302,10 +305,17 @@ func handleOllamaSetup(args []string) {
 }
 
 // promptYesNo prints question + " [Y/n] " and returns true for yes (default).
-// The caller must pass the shared scanner for the current command.
+// Returns false on EOF or read error (safe for non-interactive/piped contexts).
 func promptYesNo(question string, scanner *bufio.Scanner) bool {
 	fmt.Printf("%s [Y/n] ", question)
-	scanner.Scan()
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			fmt.Fprintf(os.Stderr, "\nUnable to read response: %v\n", err)
+		} else {
+			fmt.Fprintln(os.Stderr, "\nNo input received; defaulting to no.")
+		}
+		return false
+	}
 	ans := strings.TrimSpace(strings.ToLower(scanner.Text()))
 	return ans == "" || ans == "y" || ans == "yes"
 }
@@ -327,6 +337,7 @@ func installOllama() error {
 }
 
 // startOllamaServer starts ollama serve in the background and waits up to 15s for it to be healthy.
+// If the server doesn't become healthy, the background process is killed to avoid orphans.
 func startOllamaServer() error {
 	cmd := exec.Command("ollama", "serve")
 	cmd.Stdout = nil
@@ -346,6 +357,8 @@ func startOllamaServer() error {
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
+	// Server didn't become healthy — kill the orphaned process.
+	_ = cmd.Process.Kill()
 	return fmt.Errorf("ollama server did not become ready within 15s")
 }
 

--- a/cmd/ratchet/cmd_provider_test.go
+++ b/cmd/ratchet/cmd_provider_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestPromptYesNo_Yes(t *testing.T) {
+	for _, input := range []string{"y\n", "Y\n", "yes\n", "YES\n", "\n"} {
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		oldStdin := os.Stdin
+		os.Stdin = r
+		if _, err := w.WriteString(input); err != nil {
+			t.Fatal(err)
+		}
+		w.Close()
+
+		got := promptYesNo("test?")
+		os.Stdin = oldStdin
+
+		if !got {
+			t.Errorf("promptYesNo(%q) = false, want true", strings.TrimRight(input, "\n"))
+		}
+	}
+}
+
+func TestPromptYesNo_No(t *testing.T) {
+	for _, input := range []string{"n\n", "N\n", "no\n", "NO\n"} {
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		oldStdin := os.Stdin
+		os.Stdin = r
+		if _, err := w.WriteString(input); err != nil {
+			t.Fatal(err)
+		}
+		w.Close()
+
+		got := promptYesNo("test?")
+		os.Stdin = oldStdin
+
+		if got {
+			t.Errorf("promptYesNo(%q) = true, want false", strings.TrimRight(input, "\n"))
+		}
+	}
+}
+
+func TestInstallOllama_CommandConstructed(t *testing.T) {
+	// installOllama is not easily unit-testable without exec mocking, but we can
+	// verify the function exists and returns an error when the binary is unavailable
+	// (in CI where brew/curl may fail). Just ensure it compiles and the function
+	// is callable — execution is integration-level.
+	_ = installOllama // ensure it compiles
+}

--- a/cmd/ratchet/cmd_provider_test.go
+++ b/cmd/ratchet/cmd_provider_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"os"
 	"strings"
 	"testing"
@@ -12,15 +13,14 @@ func TestPromptYesNo_Yes(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		oldStdin := os.Stdin
-		os.Stdin = r
 		if _, err := w.WriteString(input); err != nil {
 			t.Fatal(err)
 		}
 		w.Close()
 
-		got := promptYesNo("test?")
-		os.Stdin = oldStdin
+		scanner := bufio.NewScanner(r)
+		got := promptYesNo("test?", scanner)
+		r.Close()
 
 		if !got {
 			t.Errorf("promptYesNo(%q) = false, want true", strings.TrimRight(input, "\n"))
@@ -34,15 +34,14 @@ func TestPromptYesNo_No(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		oldStdin := os.Stdin
-		os.Stdin = r
 		if _, err := w.WriteString(input); err != nil {
 			t.Fatal(err)
 		}
 		w.Close()
 
-		got := promptYesNo("test?")
-		os.Stdin = oldStdin
+		scanner := bufio.NewScanner(r)
+		got := promptYesNo("test?", scanner)
+		r.Close()
 
 		if got {
 			t.Errorf("promptYesNo(%q) = true, want false", strings.TrimRight(input, "\n"))

--- a/cmd/ratchet/cmd_provider_test.go
+++ b/cmd/ratchet/cmd_provider_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -49,10 +50,36 @@ func TestPromptYesNo_No(t *testing.T) {
 	}
 }
 
-func TestInstallOllama_CommandConstructed(t *testing.T) {
-	// installOllama is not easily unit-testable without exec mocking, but we can
-	// verify the function exists and returns an error when the binary is unavailable
-	// (in CI where brew/curl may fail). Just ensure it compiles and the function
-	// is callable — execution is integration-level.
-	_ = installOllama // ensure it compiles
+func TestPromptYesNo_EOF(t *testing.T) {
+	// When stdin is closed (EOF), promptYesNo should default to false.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Close() // immediate EOF
+
+	scanner := bufio.NewScanner(r)
+	got := promptYesNo("test?", scanner)
+	r.Close()
+
+	if got {
+		t.Error("promptYesNo on EOF should return false, got true")
+	}
+}
+
+func TestInstallOllama_UnsupportedPlatform(t *testing.T) {
+	// installOllama on the current platform should either succeed (darwin/linux)
+	// or return an "unsupported platform" error (windows/other).
+	// We can't mock runtime.GOOS, but we can verify the function is callable
+	// and returns the expected error type on non-linux/non-darwin platforms.
+	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
+		t.Skip("installOllama would attempt real install on this platform")
+	}
+	err := installOllama()
+	if err == nil {
+		t.Error("expected error on unsupported platform")
+	}
+	if !strings.Contains(err.Error(), "not supported on") {
+		t.Errorf("expected 'not supported' error, got: %v", err)
+	}
 }

--- a/cmd/ratchet/cmd_provider_test.go
+++ b/cmd/ratchet/cmd_provider_test.go
@@ -67,15 +67,42 @@ func TestPromptYesNo_EOF(t *testing.T) {
 	}
 }
 
-func TestInstallOllama_UnsupportedPlatform(t *testing.T) {
-	// installOllama on the current platform should either succeed (darwin/linux)
-	// or return an "unsupported platform" error (windows/other).
-	// We can't mock runtime.GOOS, but we can verify the function is callable
-	// and returns the expected error type on non-linux/non-darwin platforms.
-	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
-		t.Skip("installOllama would attempt real install on this platform")
+func TestOllamaInstallCommand_Darwin(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only test")
 	}
-	err := installOllama()
+	cmd, err := ollamaInstallCommand()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmd.Args[0] != "brew" {
+		t.Errorf("expected brew command on darwin, got: %v", cmd.Args)
+	}
+}
+
+func TestOllamaInstallCommand_Linux(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux-only test")
+	}
+	cmd, err := ollamaInstallCommand()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmd.Args[0] != "sh" {
+		t.Errorf("expected sh command on linux, got: %v", cmd.Args)
+	}
+	// Verify it downloads to temp file instead of piping to sh
+	joined := strings.Join(cmd.Args, " ")
+	if !strings.Contains(joined, "mktemp") {
+		t.Errorf("expected mktemp-based download, got: %s", joined)
+	}
+}
+
+func TestOllamaInstallCommand_UnsupportedPlatform(t *testing.T) {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
+		t.Skip("only runs on unsupported platforms")
+	}
+	_, err := ollamaInstallCommand()
 	if err == nil {
 		t.Error("expected error on unsupported platform")
 	}

--- a/cmd/ratchet/main.go
+++ b/cmd/ratchet/main.go
@@ -56,6 +56,8 @@ func main() {
 		handlePlugin(filteredArgs[1:])
 	case "skill":
 		handleSkill(filteredArgs[1:])
+	case "model":
+		handleModel(filteredArgs[1:])
 	case "config":
 		handleConfig(filteredArgs[1:])
 	case "chat":
@@ -129,6 +131,7 @@ Commands:
 
   daemon           Manage background daemon
   sessions         Manage sessions
+  model            Manage local models (list, pull)
   provider         Manage AI providers
   agent            Manage agent definitions
   team             Multi-agent orchestration

--- a/docs/plans/2026-04-05-seamless-local-model-setup-design.md
+++ b/docs/plans/2026-04-05-seamless-local-model-setup-design.md
@@ -1,0 +1,72 @@
+# Seamless Local Model Setup Design
+
+**Date:** 2026-04-05
+**Repo:** ratchet-cli
+**Goal:** Wire up automatic local model setup so first-run users can go from zero to a working local LLM with minimal friction.
+
+## First-Run Auto-Wizard
+
+On TUI startup, if `ListProviders()` returns empty, automatically navigate to the onboarding wizard. The empty providers table is the signal — no flag file needed. Implemented in `app.go` after the initial page transition.
+
+## Enhanced CLI: `ratchet provider setup ollama`
+
+Current behavior: prints `ollama pull <model>` as a manual step.
+
+New flow:
+
+1. **Check for `ollama` binary** — `exec.LookPath("ollama")`
+   - If missing, prompt: "Ollama not found. Install it? [Y/n]"
+   - If yes: `brew install ollama` (macOS via `runtime.GOOS == "darwin"`) or `curl -fsSL https://ollama.com/install.sh | sh` (Linux)
+   - If no: print manual install URL and exit
+2. **Check if server running** — `OllamaClient.Health(ctx)`
+   - If not running, start it: `exec.Command("ollama", "serve")` in background
+   - Wait up to 10s for health check to pass
+3. **List installed models** — `OllamaClient.ListModels(ctx)`
+   - If models exist, show them and ask which to use (or skip)
+   - If none installed, show curated recommendations:
+     - `qwen3:8b` (8GB, fast, good tool use)
+     - `llama3.3:8b` (8GB, general purpose)
+     - `gemma3:4b` (4GB, lightweight)
+     - Custom (user types model name)
+4. **Pull selected model** — `OllamaClient.Pull(ctx, model, progressFn)` with progress bar
+5. **Auto-register provider** — ensure daemon running, call `AddProvider` RPC with alias "ollama", type "ollama", model, baseURL `http://localhost:11434`, isDefault true
+6. **Test connection** — call `TestProvider` RPC, show result
+
+## TUI Onboarding: Ollama Model Pull
+
+When user selects "Local models (Ollama)" in the onboarding wizard:
+
+1. Health check Ollama at configured base URL
+2. If not running → show error with install/start instructions (no TUI auto-install — keep TUI simple, CLI handles heavy lifting)
+3. Fetch models via `OllamaClient.ListModels()`
+4. If no models installed → show "No models found" with recommended models list and "Pull now?" option
+5. On model selection → `OllamaClient.Pull()` with TUI progress spinner
+6. Proceed to test connection as normal
+
+## New CLI: `ratchet model`
+
+```
+ratchet model list                                    — list installed Ollama models
+ratchet model pull <name>                             — pull model via Ollama
+ratchet model pull --from huggingface <repo> <file>   — download GGUF from HuggingFace
+```
+
+Thin wrappers around `OllamaClient` and `DownloadHuggingFaceFile()` from workflow-plugin-agent.
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `cmd/ratchet/cmd_provider.go` | Rewrite `handleOllamaSetup` — auto-install, pull, register |
+| `cmd/ratchet/cmd_model.go` | NEW — model list/pull commands |
+| `cmd/ratchet/main.go` | Register `model` subcommand |
+| `internal/tui/app.go` | First-run: if no providers, auto-navigate to onboarding |
+| `internal/tui/pages/onboarding.go` | Add model pull flow for Ollama when no models installed |
+
+## Not In Scope (Future)
+
+- HuggingFace authentication (gated/private models)
+- Model configuration and management UI in TUI
+- Advanced model selection (size filtering, capability matching)
+- Background auto-detection at daemon startup
+- llama.cpp binary management (Ollama subsumes this)

--- a/docs/plans/2026-04-05-seamless-local-model-setup.md
+++ b/docs/plans/2026-04-05-seamless-local-model-setup.md
@@ -1,0 +1,182 @@
+# Seamless Local Model Setup — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Wire up automatic local model setup so first-run users can go from zero to a working local LLM with `ratchet provider setup ollama` or through the TUI onboarding wizard.
+
+**Architecture:** Rewrite `handleOllamaSetup` to auto-install Ollama (with user confirmation), auto-pull a model via `OllamaClient.Pull()`, and auto-register the provider. Enhance TUI onboarding to offer model pulling when Ollama has no models. Add `ratchet model` CLI for ad-hoc model management.
+
+**Tech Stack:** Go 1.26, workflow-plugin-agent v0.6.0 (`OllamaClient`, `DownloadHuggingFaceFile`), Bubbletea v2
+
+---
+
+## Task 1: Rewrite `ratchet provider setup ollama` — auto-install, pull, register
+
+**Files:**
+- Modify: `cmd/ratchet/cmd_provider.go`
+
+**Step 1:** Replace `handleOllamaSetup` with a complete setup flow that:
+
+1. Parses `--model` flag (default: `qwen3:8b`)
+2. Checks for `ollama` binary via `exec.LookPath`
+   - If missing: prompt "Ollama not found. Install it? [Y/n]" via `fmt.Scanln`
+   - If yes + macOS (`runtime.GOOS == "darwin"`): run `brew install ollama`
+   - If yes + Linux: run `sh -c "curl -fsSL https://ollama.com/install.sh | sh"`
+   - If no: print install URL and return
+3. Check server health via `provider.NewOllamaClient("").Health(ctx)`
+   - If not running: start `ollama serve` in background via `exec.Command`, wait up to 15s polling Health
+4. List installed models via `OllamaClient.ListModels(ctx)`
+   - If models exist: print them, ask if user wants to use one or pull a new one
+5. If no models (or user wants new): show recommended list, prompt selection, pull via `OllamaClient.Pull(ctx, model, progressFn)` with a terminal progress bar
+6. Ensure daemon running via `client.EnsureDaemon()`
+7. Register provider: `c.AddProvider(ctx, &pb.AddProviderReq{Alias: "ollama", Type: "ollama", Model: model, BaseUrl: "http://localhost:11434", IsDefault: true})`
+8. Test connection: `c.TestProvider(ctx, "ollama")`
+9. Print success summary
+
+**Step 2:** Add helper functions in the same file:
+- `promptYesNo(question string) bool` — reads Y/n from stdin
+- `installOllama() error` — OS-detect + exec brew/curl
+- `startOllamaServer() error` — background exec + health poll
+- `pullModelWithProgress(ctx, client, model string)` — calls `OllamaClient.Pull` with terminal progress output
+- `promptModelSelection(models []provider.ModelInfo) string` — show numbered list, read selection
+
+**Step 3:** Add imports: `runtime`, `bufio`, `strings`, `provider` from workflow-plugin-agent
+
+**Step 4:** Build and verify: `go build ./cmd/ratchet/`
+
+**Step 5:** Commit:
+```bash
+git add cmd/ratchet/cmd_provider.go
+git commit -m "feat: rewrite ollama setup with auto-install, pull, and register"
+```
+
+---
+
+## Task 2: Add `ratchet model` CLI command
+
+**Files:**
+- Create: `cmd/ratchet/cmd_model.go`
+- Modify: `cmd/ratchet/main.go`
+
+**Step 1:** Create `cmd/ratchet/cmd_model.go` with:
+
+```
+ratchet model list                                  — list installed Ollama models
+ratchet model pull <name>                           — pull model via Ollama
+ratchet model pull --from huggingface <repo> <file> — download GGUF from HuggingFace
+```
+
+`handleModel(args []string)`:
+- `list`: call `OllamaClient.ListModels(ctx)`, print table (NAME, SIZE, MODIFIED)
+- `pull`: if `--from huggingface`, call `provider.DownloadHuggingFaceFile(ctx, repo, file, "", progressFn)`; else call `OllamaClient.Pull(ctx, name, progressFn)`
+- Default baseURL from config or `http://localhost:11434`
+
+**Step 2:** Register in `main.go`:
+```go
+case "model":
+    handleModel(filteredArgs[1:])
+```
+
+**Step 3:** Build and test: `go build ./cmd/ratchet/ && ./ratchet model --help`
+
+**Step 4:** Commit:
+```bash
+git add cmd/ratchet/cmd_model.go cmd/ratchet/main.go
+git commit -m "feat: add ratchet model list/pull CLI command"
+```
+
+---
+
+## Task 3: Enhance TUI onboarding — model pull when Ollama has no models
+
+**Files:**
+- Modify: `internal/tui/pages/onboarding.go`
+
+**Step 1:** Add a new onboarding step `stepPullModel` between `stepFetchModels` and `stepSelectModel`:
+- Add to the `onboardingStep` enum: `stepPullModel`
+- Add fields to `OnboardingModel`: `pullingModel bool`, `pullProgress float64`, `pullModelName string`, `recommendedModels []string`
+
+**Step 2:** In the `modelsListMsg` handler (around line 269), when `len(msg.models) == 0` and provider is `ollama`:
+- Instead of going to `stepSelectModel` with empty list, transition to `stepPullModel`
+- Set `recommendedModels` to `[]string{"qwen3:8b", "llama3.3:8b", "gemma3:4b"}`
+
+**Step 3:** Implement `updatePullModel(msg tea.Msg)`:
+- Render a selection list of recommended models
+- On Enter: start pulling via async command that calls `OllamaClient.Pull` with progress callback
+- Progress updates via `pullProgressMsg{pct float64}` tea.Msg sent periodically
+- On completion: re-fetch models and transition to `stepSelectModel`
+
+**Step 4:** Implement `viewPullModel()`:
+- Show "No models installed. Pull one to get started:"
+- Numbered list of recommended models
+- If pulling: show spinner + progress percentage
+- Esc to go back
+
+**Step 5:** Wire into the step routing in `Update()` and `View()`.
+
+**Step 6:** Build and test: `go build ./...`
+
+**Step 7:** Commit:
+```bash
+git add internal/tui/pages/onboarding.go
+git commit -m "feat: add model pull flow to TUI onboarding for Ollama"
+```
+
+---
+
+## Task 4: Write tests
+
+**Files:**
+- Create: `cmd/ratchet/cmd_provider_test.go`
+- Create: `cmd/ratchet/cmd_model_test.go`
+
+**Step 1:** Test helper functions in `cmd_provider.go`:
+- `TestPromptYesNo` — mock stdin, verify yes/no parsing
+- `TestInstallOllama_Darwin` / `TestInstallOllama_Linux` — verify correct command constructed (don't actually exec)
+
+**Step 2:** Test model command parsing in `cmd_model.go`:
+- `TestHandleModel_List_NoServer` — verify graceful error when Ollama not running
+- `TestHandleModel_Pull_MissingName` — verify usage message
+
+**Step 3:** Run tests: `go test ./cmd/ratchet/ -v -count=1`
+
+**Step 4:** Run full suite: `go test ./... -count=1`
+
+**Step 5:** Commit:
+```bash
+git add cmd/ratchet/cmd_provider_test.go cmd/ratchet/cmd_model_test.go
+git commit -m "test: add tests for provider setup and model commands"
+```
+
+---
+
+## Task 5: Verify first-run auto-wizard still works
+
+**Files:** No changes needed — verify only.
+
+The first-run auto-wizard is already implemented in `internal/tui/app.go:271`:
+```go
+func (a App) transitionFromSplash() (tea.Model, tea.Cmd) {
+    if a.reconfigure || len(a.providers) == 0 {
+        // → onboarding wizard
+    }
+}
+```
+
+**Step 1:** Verify by reading the code path: `app.go Init()` → `checkProviders()` → `ProvidersCheckedMsg` → `transitionFromSplash()` → if empty → onboarding.
+
+**Step 2:** Run `go build ./...` to confirm no regressions.
+
+**Step 3:** Run `go test ./... -count=1` for full regression.
+
+**Step 4:** Commit (if any fixes needed).
+
+---
+
+## Execution Order
+
+```
+Task 1 (CLI setup rewrite) → Task 2 (model command) → Task 3 (TUI pull flow) → Task 4 (tests) → Task 5 (verify)
+```
+
+All tasks are sequential — Task 1 establishes helpers reused by Task 2, Task 3 uses similar patterns, Task 4 tests everything.

--- a/docs/plans/2026-04-05-seamless-local-model-setup.md
+++ b/docs/plans/2026-04-05-seamless-local-model-setup.md
@@ -1,7 +1,5 @@
 # Seamless Local Model Setup — Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
-
 **Goal:** Wire up automatic local model setup so first-run users can go from zero to a working local LLM with `ratchet provider setup ollama` or through the TUI onboarding wizard.
 
 **Architecture:** Rewrite `handleOllamaSetup` to auto-install Ollama (with user confirmation), auto-pull a model via `OllamaClient.Pull()`, and auto-register the provider. Enhance TUI onboarding to offer model pulling when Ollama has no models. Add `ratchet model` CLI for ad-hoc model management.
@@ -67,7 +65,7 @@ ratchet model pull --from huggingface <repo> <file> — download GGUF from Huggi
 ```
 
 `handleModel(args []string)`:
-- `list`: call `OllamaClient.ListModels(ctx)`, print table (NAME, SIZE, MODIFIED)
+- `list`: call `OllamaClient.ListModels(ctx)`, print table (NAME, CONTEXT)
 - `pull`: if `--from huggingface`, call `provider.DownloadHuggingFaceFile(ctx, repo, file, "", progressFn)`; else call `OllamaClient.Pull(ctx, name, progressFn)`
 - Default baseURL from config or `http://localhost:11434`
 

--- a/internal/tui/pages/onboarding.go
+++ b/internal/tui/pages/onboarding.go
@@ -167,6 +167,8 @@ type OnboardingModel struct {
 	pullError         string
 	pullProgressCh    chan float64
 	pullDoneCh        chan error
+	pullCustomInput   textinput.Model
+	pullEnteringCustom bool
 
 	// Model selection
 	modelCursor int
@@ -631,14 +633,39 @@ func (m OnboardingModel) updatePullModel(msg tea.Msg) (OnboardingModel, tea.Cmd)
 	if m.pullingModel {
 		return m, nil
 	}
+
+	// Custom model name entry mode.
+	if m.pullEnteringCustom {
+		if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
+			switch keyMsg.String() {
+			case "esc":
+				m.pullEnteringCustom = false
+				m.pullCustomInput.SetValue("")
+				return m, nil
+			case "enter":
+				name := strings.TrimSpace(m.pullCustomInput.Value())
+				if name == "" {
+					return m, nil
+				}
+				m.pullEnteringCustom = false
+				m.pullModelName = name
+				return m.startPull()
+			}
+		}
+		var cmd tea.Cmd
+		m.pullCustomInput, cmd = m.pullCustomInput.Update(msg)
+		return m, cmd
+	}
+
 	if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
+		customIdx := len(m.recommendedModels) // index for the "Custom" row
 		switch keyMsg.String() {
 		case "esc":
 			m.step = stepSelectProvider
 			m.cursor = m.providerIdx
 			return m, nil
 		case "j", "down":
-			if m.pullCursor < len(m.recommendedModels) {
+			if m.pullCursor < customIdx {
 				m.pullCursor++
 			}
 		case "k", "up":
@@ -646,37 +673,49 @@ func (m OnboardingModel) updatePullModel(msg tea.Msg) (OnboardingModel, tea.Cmd)
 				m.pullCursor--
 			}
 		case "enter", " ":
-			if m.pullCursor < len(m.recommendedModels) {
-				m.pullModelName = m.recommendedModels[m.pullCursor]
-			} else {
-				m.pullModelName = m.recommendedModels[0]
+			if m.pullCursor == customIdx {
+				// Enter custom model name
+				m.pullEnteringCustom = true
+				m.pullCustomInput = textinput.New()
+				m.pullCustomInput.Placeholder = "e.g. mistral:7b"
+				m.pullCustomInput.Prompt = ""
+				return m, m.pullCustomInput.Focus()
 			}
-			m.pullingModel = true
-			m.pullProgress = 0
-			m.pullError = ""
-			progressCh := make(chan float64, 50)
-			doneCh := make(chan error, 1)
-			m.pullProgressCh = progressCh
-			m.pullDoneCh = doneCh
-			baseURL := m.baseURLInput.Value()
-			pullName := m.pullModelName
-			go func() {
-				c := wfprovider.NewOllamaClient(baseURL)
-				err := c.Pull(context.Background(), pullName, func(pct float64) {
-					progressCh <- pct
-				})
-				doneCh <- err
-			}()
-			return m, tea.Batch(m.spinner.Tick, m.readPullProgress())
+			m.pullModelName = m.recommendedModels[m.pullCursor]
+			return m.startPull()
 		}
-		// Number shortcuts
+		// Number shortcuts (1 = recommended[0], ..., N+1 = Custom)
 		for i := range m.recommendedModels {
 			if keyMsg.String() == fmt.Sprintf("%d", i+1) {
 				m.pullCursor = i
 			}
 		}
+		if keyMsg.String() == fmt.Sprintf("%d", customIdx+1) {
+			m.pullCursor = customIdx
+		}
 	}
 	return m, nil
+}
+
+// startPull initiates the async model pull and returns the updated model and initial tea.Cmd.
+func (m OnboardingModel) startPull() (OnboardingModel, tea.Cmd) {
+	m.pullingModel = true
+	m.pullProgress = 0
+	m.pullError = ""
+	progressCh := make(chan float64, 50)
+	doneCh := make(chan error, 1)
+	m.pullProgressCh = progressCh
+	m.pullDoneCh = doneCh
+	baseURL := m.baseURLInput.Value()
+	pullName := m.pullModelName
+	go func() {
+		c := wfprovider.NewOllamaClient(baseURL)
+		err := c.Pull(context.Background(), pullName, func(pct float64) {
+			progressCh <- pct
+		})
+		doneCh <- err
+	}()
+	return m, tea.Batch(m.spinner.Tick, m.readPullProgress())
 }
 
 // readPullProgress returns a tea.Cmd that waits for the next pull progress update.
@@ -960,23 +999,38 @@ func (m OnboardingModel) View(t theme.Theme, width, height int) string {
 		sb.WriteString(mutedStyle.Render("Esc: cancel"))
 
 	case stepPullModel:
-		sb.WriteString("No models installed. Pull one to get started:\n\n")
-		for i, name := range m.recommendedModels {
-			cursor := "  "
-			style := mutedStyle
-			if i == m.pullCursor {
-				cursor = "▶ "
-				style = lipgloss.NewStyle().Foreground(t.Foreground).Bold(true)
-			}
-			sb.WriteString(style.Render(fmt.Sprintf("%s%d. %s", cursor, i+1, name)) + "\n")
-		}
-		if m.pullingModel {
-			sb.WriteString(fmt.Sprintf("\n%s Pulling %s... %.0f%%\n", m.spinner.View(), m.pullModelName, m.pullProgress))
-		} else if m.pullError != "" {
-			sb.WriteString("\n" + errorStyle.Render("Pull failed: "+m.pullError) + "\n")
-			sb.WriteString(mutedStyle.Render("Enter: retry  Esc: back"))
+		customIdx := len(m.recommendedModels)
+		if m.pullEnteringCustom {
+			sb.WriteString("Enter model name to pull:\n\n")
+			sb.WriteString("Model: " + m.pullCustomInput.View() + "\n\n")
+			sb.WriteString(mutedStyle.Render("Enter: pull  Esc: back"))
 		} else {
-			sb.WriteString("\n" + mutedStyle.Render(fmt.Sprintf("↑/↓ or 1-%d: select  Enter: pull  Esc: back", len(m.recommendedModels))))
+			sb.WriteString("No models installed. Pull one to get started:\n\n")
+			for i, name := range m.recommendedModels {
+				cursor := "  "
+				style := mutedStyle
+				if i == m.pullCursor {
+					cursor = "▶ "
+					style = lipgloss.NewStyle().Foreground(t.Foreground).Bold(true)
+				}
+				sb.WriteString(style.Render(fmt.Sprintf("%s%d. %s", cursor, i+1, name)) + "\n")
+			}
+			// Custom row
+			customCursor := "  "
+			customStyle := mutedStyle
+			if m.pullCursor == customIdx {
+				customCursor = "▶ "
+				customStyle = lipgloss.NewStyle().Foreground(t.Foreground).Bold(true)
+			}
+			sb.WriteString(customStyle.Render(fmt.Sprintf("%s%d. Custom (enter model name)", customCursor, customIdx+1)) + "\n")
+			if m.pullingModel {
+				fmt.Fprintf(&sb, "\n%s Pulling %s... %.0f%%\n", m.spinner.View(), m.pullModelName, m.pullProgress)
+			} else if m.pullError != "" {
+				sb.WriteString("\n" + errorStyle.Render("Pull failed: "+m.pullError) + "\n")
+				sb.WriteString(mutedStyle.Render("Enter: retry  Esc: back"))
+			} else {
+				sb.WriteString("\n" + mutedStyle.Render(fmt.Sprintf("↑/↓ or 1-%d: select  Enter: pull  Esc: back", customIdx+1)))
+			}
 		}
 
 	case stepSelectModel:

--- a/internal/tui/pages/onboarding.go
+++ b/internal/tui/pages/onboarding.go
@@ -295,7 +295,12 @@ func (m OnboardingModel) Update(msg tea.Msg) (OnboardingModel, tea.Cmd) {
 		m.fetchedModels = msg.models
 		m.modelCursor = 0
 		// When Ollama has no models installed, offer to pull one.
-		if len(msg.models) == 0 && msg.err == nil && m.selectedProvider().name == "ollama" {
+		// Only trigger for actual Ollama servers (default base URL or localhost:11434),
+		// not for other OpenAI-compatible servers (LM Studio, vLLM) where the
+		// Ollama pull API won't work.
+		isOllamaServer := m.selectedProvider().name == "ollama" &&
+			(m.baseURLInput.Value() == "" || strings.Contains(m.baseURLInput.Value(), "localhost:11434") || strings.Contains(m.baseURLInput.Value(), "127.0.0.1:11434"))
+		if len(msg.models) == 0 && msg.err == nil && isOllamaServer {
 			m.step = stepPullModel
 			m.pullCursor = 0
 			m.pullError = ""
@@ -731,6 +736,7 @@ func (m OnboardingModel) startPull() (OnboardingModel, tea.Cmd) {
 	baseURL := m.baseURLInput.Value()
 	pullName := m.pullModelName
 	go func() {
+		defer close(progressCh) // signal readPullProgress that no more updates are coming
 		c := wfprovider.NewOllamaClient(baseURL)
 		err := c.Pull(ctx, pullName, func(pct float64) {
 			select {
@@ -751,14 +757,22 @@ func (m OnboardingModel) startPull() (OnboardingModel, tea.Cmd) {
 }
 
 // readPullProgress returns a tea.Cmd that waits for the next pull progress update.
+// Prioritizes doneCh so completion isn't delayed by buffered progress updates.
 func (m OnboardingModel) readPullProgress() tea.Cmd {
 	return func() tea.Msg {
+		// Check doneCh first (non-blocking) to prioritize completion.
+		select {
+		case err := <-m.pullDoneCh:
+			return pullDoneMsg{err: err}
+		default:
+		}
+		// Wait for either progress or done.
 		select {
 		case pct, ok := <-m.pullProgressCh:
 			if ok {
 				return pullProgressMsg{pct: pct}
 			}
-			// Channel closed before done — drain doneCh
+			// progressCh closed — pull goroutine finished, read result.
 			err := <-m.pullDoneCh
 			return pullDoneMsg{err: err}
 		case err := <-m.pullDoneCh:

--- a/internal/tui/pages/onboarding.go
+++ b/internal/tui/pages/onboarding.go
@@ -15,6 +15,7 @@ import (
 	providerauth "github.com/GoCodeAlone/ratchet-cli/internal/provider"
 	pb "github.com/GoCodeAlone/ratchet-cli/internal/proto"
 	"github.com/GoCodeAlone/ratchet-cli/internal/tui/theme"
+	wfprovider "github.com/GoCodeAlone/workflow-plugin-agent/provider"
 )
 
 // OnboardingDoneMsg signals provider setup is complete.
@@ -53,6 +54,12 @@ type modelsListMsg struct {
 	err    error
 }
 
+// pullProgressMsg carries a model pull progress update (0–100).
+type pullProgressMsg struct{ pct float64 }
+
+// pullDoneMsg signals a model pull completed or failed.
+type pullDoneMsg struct{ err error }
+
 type onboardingStep int
 
 const (
@@ -62,6 +69,7 @@ const (
 	stepEnterAPIKey
 	stepEnterBaseURL
 	stepFetchModels
+	stepPullModel
 	stepSelectModel
 	stepTestConnection
 )
@@ -150,6 +158,16 @@ type OnboardingModel struct {
 	fetchedModels  []providerauth.ModelInfo
 	modelsError    string
 
+	// Model pull (stepPullModel)
+	pullingModel      bool
+	pullProgress      float64
+	pullModelName     string
+	pullCursor        int
+	recommendedModels []string
+	pullError         string
+	pullProgressCh    chan float64
+	pullDoneCh        chan error
+
 	// Model selection
 	modelCursor int
 
@@ -210,7 +228,7 @@ func (m OnboardingModel) Update(msg tea.Msg) (OnboardingModel, tea.Cmd) {
 	// screens all dismiss properly. For the API key entry step, the step-specific
 	// handler routes back to the Anthropic auth choice when appropriate.
 	if keyMsg, ok := msg.(tea.KeyPressMsg); ok && keyMsg.String() == "esc" {
-		if m.step != stepSelectProvider && m.step != stepEnterAPIKey && m.step != stepAnthropicAuthChoice {
+		if m.step != stepSelectProvider && m.step != stepEnterAPIKey && m.step != stepAnthropicAuthChoice && m.step != stepPullModel {
 			if m.authCancel != nil {
 				m.authCancel()
 				m.authCancel = nil
@@ -273,8 +291,30 @@ func (m OnboardingModel) Update(msg tea.Msg) (OnboardingModel, tea.Cmd) {
 		}
 		m.fetchedModels = msg.models
 		m.modelCursor = 0
+		// When Ollama has no models installed, offer to pull one.
+		if len(msg.models) == 0 && msg.err == nil && m.selectedProvider().name == "ollama" {
+			m.step = stepPullModel
+			m.pullCursor = 0
+			m.pullError = ""
+			m.pullingModel = false
+			m.recommendedModels = []string{"qwen3:8b", "llama3.3:8b", "gemma3:4b"}
+			return m, nil
+		}
 		m.step = stepSelectModel
 		return m, nil
+
+	case pullProgressMsg:
+		m.pullProgress = msg.pct
+		return m, m.readPullProgress()
+
+	case pullDoneMsg:
+		m.pullingModel = false
+		if msg.err != nil {
+			m.pullError = msg.err.Error()
+			return m, nil
+		}
+		// Pull succeeded — re-fetch models and proceed to selection.
+		return m.transitionToFetchModels()
 
 	case providerAddedMsg:
 		if msg.err != nil {
@@ -298,7 +338,7 @@ func (m OnboardingModel) Update(msg tea.Msg) (OnboardingModel, tea.Cmd) {
 		return m, nil
 
 	case spinner.TickMsg:
-		if m.testing || m.authing || m.fetchingModels {
+		if m.testing || m.authing || m.fetchingModels || m.pullingModel {
 			var cmd tea.Cmd
 			m.spinner, cmd = m.spinner.Update(msg)
 			return m, cmd
@@ -319,6 +359,8 @@ func (m OnboardingModel) Update(msg tea.Msg) (OnboardingModel, tea.Cmd) {
 		return m.updateEnterBaseURL(msg)
 	case stepFetchModels:
 		return m.updateFetchModels(msg)
+	case stepPullModel:
+		return m.updatePullModel(msg)
 	case stepSelectModel:
 		return m.updateSelectModel(msg)
 	case stepTestConnection:
@@ -585,6 +627,75 @@ func (m OnboardingModel) updateFetchModels(msg tea.Msg) (OnboardingModel, tea.Cm
 	return m, nil
 }
 
+func (m OnboardingModel) updatePullModel(msg tea.Msg) (OnboardingModel, tea.Cmd) {
+	if m.pullingModel {
+		return m, nil
+	}
+	if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
+		switch keyMsg.String() {
+		case "esc":
+			m.step = stepSelectProvider
+			m.cursor = m.providerIdx
+			return m, nil
+		case "j", "down":
+			if m.pullCursor < len(m.recommendedModels) {
+				m.pullCursor++
+			}
+		case "k", "up":
+			if m.pullCursor > 0 {
+				m.pullCursor--
+			}
+		case "enter", " ":
+			if m.pullCursor < len(m.recommendedModels) {
+				m.pullModelName = m.recommendedModels[m.pullCursor]
+			} else {
+				m.pullModelName = m.recommendedModels[0]
+			}
+			m.pullingModel = true
+			m.pullProgress = 0
+			m.pullError = ""
+			progressCh := make(chan float64, 50)
+			doneCh := make(chan error, 1)
+			m.pullProgressCh = progressCh
+			m.pullDoneCh = doneCh
+			baseURL := m.baseURLInput.Value()
+			pullName := m.pullModelName
+			go func() {
+				c := wfprovider.NewOllamaClient(baseURL)
+				err := c.Pull(context.Background(), pullName, func(pct float64) {
+					progressCh <- pct
+				})
+				doneCh <- err
+			}()
+			return m, tea.Batch(m.spinner.Tick, m.readPullProgress())
+		}
+		// Number shortcuts
+		for i := range m.recommendedModels {
+			if keyMsg.String() == fmt.Sprintf("%d", i+1) {
+				m.pullCursor = i
+			}
+		}
+	}
+	return m, nil
+}
+
+// readPullProgress returns a tea.Cmd that waits for the next pull progress update.
+func (m OnboardingModel) readPullProgress() tea.Cmd {
+	return func() tea.Msg {
+		select {
+		case pct, ok := <-m.pullProgressCh:
+			if ok {
+				return pullProgressMsg{pct: pct}
+			}
+			// Channel closed before done — drain doneCh
+			err := <-m.pullDoneCh
+			return pullDoneMsg{err: err}
+		case err := <-m.pullDoneCh:
+			return pullDoneMsg{err: err}
+		}
+	}
+}
+
 func (m OnboardingModel) updateSelectModel(msg tea.Msg) (OnboardingModel, tea.Cmd) {
 	models := m.fetchedModels
 	if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
@@ -848,6 +959,26 @@ func (m OnboardingModel) View(t theme.Theme, width, height int) string {
 		sb.WriteString(m.spinner.View() + " Loading available models from " + p.displayName + "...\n\n")
 		sb.WriteString(mutedStyle.Render("Esc: cancel"))
 
+	case stepPullModel:
+		sb.WriteString("No models installed. Pull one to get started:\n\n")
+		for i, name := range m.recommendedModels {
+			cursor := "  "
+			style := mutedStyle
+			if i == m.pullCursor {
+				cursor = "▶ "
+				style = lipgloss.NewStyle().Foreground(t.Foreground).Bold(true)
+			}
+			sb.WriteString(style.Render(fmt.Sprintf("%s%d. %s", cursor, i+1, name)) + "\n")
+		}
+		if m.pullingModel {
+			sb.WriteString(fmt.Sprintf("\n%s Pulling %s... %.0f%%\n", m.spinner.View(), m.pullModelName, m.pullProgress))
+		} else if m.pullError != "" {
+			sb.WriteString("\n" + errorStyle.Render("Pull failed: "+m.pullError) + "\n")
+			sb.WriteString(mutedStyle.Render("Enter: retry  Esc: back"))
+		} else {
+			sb.WriteString("\n" + mutedStyle.Render(fmt.Sprintf("↑/↓ or 1-%d: select  Enter: pull  Esc: back", len(m.recommendedModels))))
+		}
+
 	case stepSelectModel:
 		models := m.fetchedModels
 		if m.modelsError != "" || len(models) == 0 {
@@ -944,7 +1075,7 @@ func (m OnboardingModel) currentStepIndex() int {
 			idx++
 		}
 		return idx
-	case stepFetchModels, stepSelectModel:
+	case stepFetchModels, stepPullModel, stepSelectModel:
 		idx := 1
 		if p.auth != authNone {
 			idx++

--- a/internal/tui/pages/onboarding.go
+++ b/internal/tui/pages/onboarding.go
@@ -326,7 +326,13 @@ func (m OnboardingModel) Update(msg tea.Msg) (OnboardingModel, tea.Cmd) {
 			return m, nil
 		}
 		if msg.err == context.Canceled {
-			// User cancelled — stay on stepPullModel with cleared state.
+			// User cancelled — reset pull state and return to provider selection.
+			m.pullError = ""
+			m.pullModelName = ""
+			m.pullProgress = 0
+			m.pullingModel = false
+			m.step = stepSelectProvider
+			m.cursor = m.providerIdx
 			return m, nil
 		}
 		// Pull succeeded — re-fetch models and proceed to selection.

--- a/internal/tui/pages/onboarding.go
+++ b/internal/tui/pages/onboarding.go
@@ -159,15 +159,16 @@ type OnboardingModel struct {
 	modelsError    string
 
 	// Model pull (stepPullModel)
-	pullingModel      bool
-	pullProgress      float64
-	pullModelName     string
-	pullCursor        int
-	recommendedModels []string
-	pullError         string
-	pullProgressCh    chan float64
-	pullDoneCh        chan error
-	pullCustomInput   textinput.Model
+	pullingModel       bool
+	pullProgress       float64
+	pullModelName      string
+	pullCursor         int
+	recommendedModels  []string
+	pullError          string
+	pullProgressCh     chan float64
+	pullDoneCh         chan error
+	pullCancel         context.CancelFunc
+	pullCustomInput    textinput.Model
 	pullEnteringCustom bool
 
 	// Model selection
@@ -311,8 +312,16 @@ func (m OnboardingModel) Update(msg tea.Msg) (OnboardingModel, tea.Cmd) {
 
 	case pullDoneMsg:
 		m.pullingModel = false
-		if msg.err != nil {
+		if m.pullCancel != nil {
+			m.pullCancel()
+			m.pullCancel = nil
+		}
+		if msg.err != nil && msg.err != context.Canceled {
 			m.pullError = msg.err.Error()
+			return m, nil
+		}
+		if msg.err == context.Canceled {
+			// User cancelled — stay on stepPullModel with cleared state.
 			return m, nil
 		}
 		// Pull succeeded — re-fetch models and proceed to selection.
@@ -630,7 +639,18 @@ func (m OnboardingModel) updateFetchModels(msg tea.Msg) (OnboardingModel, tea.Cm
 }
 
 func (m OnboardingModel) updatePullModel(msg tea.Msg) (OnboardingModel, tea.Cmd) {
+	// Allow Esc to cancel an in-progress pull.
 	if m.pullingModel {
+		if keyMsg, ok := msg.(tea.KeyPressMsg); ok && keyMsg.String() == "esc" {
+			if m.pullCancel != nil {
+				m.pullCancel()
+				m.pullCancel = nil
+			}
+			m.pullingModel = false
+			m.pullError = ""
+			m.step = stepSelectProvider
+			m.cursor = m.providerIdx
+		}
 		return m, nil
 	}
 
@@ -706,12 +726,17 @@ func (m OnboardingModel) startPull() (OnboardingModel, tea.Cmd) {
 	doneCh := make(chan error, 1)
 	m.pullProgressCh = progressCh
 	m.pullDoneCh = doneCh
+	ctx, cancel := context.WithCancel(context.Background())
+	m.pullCancel = cancel
 	baseURL := m.baseURLInput.Value()
 	pullName := m.pullModelName
 	go func() {
 		c := wfprovider.NewOllamaClient(baseURL)
-		err := c.Pull(context.Background(), pullName, func(pct float64) {
-			progressCh <- pct
+		err := c.Pull(ctx, pullName, func(pct float64) {
+			select {
+			case progressCh <- pct:
+			case <-ctx.Done():
+			}
 		})
 		doneCh <- err
 	}()

--- a/internal/tui/pages/onboarding.go
+++ b/internal/tui/pages/onboarding.go
@@ -734,8 +734,15 @@ func (m OnboardingModel) startPull() (OnboardingModel, tea.Cmd) {
 		c := wfprovider.NewOllamaClient(baseURL)
 		err := c.Pull(ctx, pullName, func(pct float64) {
 			select {
-			case progressCh <- pct:
 			case <-ctx.Done():
+				return
+			default:
+			}
+			// Non-blocking send: drop progress updates if UI can't keep up
+			// to avoid backpressuring the download.
+			select {
+			case progressCh <- pct:
+			default:
 			}
 		})
 		doneCh <- err


### PR DESCRIPTION
## Summary

- **`ratchet provider setup ollama`** — complete rewrite: auto-installs Ollama (brew/curl with user confirmation), auto-starts server, lists/recommends models, pulls via `OllamaClient.Pull()` with progress bar, registers provider as default, tests connection
- **`ratchet model list/pull`** — new CLI: list installed Ollama models, pull by name, pull from HuggingFace (`--from huggingface <repo> <file>`)
- **TUI onboarding** — when Ollama has no models installed, shows recommended models list with pull flow (spinner + progress), including custom model name entry
- **First-run auto-wizard** — already existed (app.go:271), verified working: empty providers → onboarding

## Quality fixes
- TUI pull goroutine uses cancellable context (Esc aborts pull cleanly)
- Single shared `bufio.Scanner` for all stdin prompts (no input loss when piped)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes
- [x] Spec review: 7/7 design requirements verified
- [x] Quality review: all issues resolved
- [ ] Manual: run `ratchet provider setup ollama` end-to-end
- [ ] Manual: run `ratchet model pull qwen3:8b` with Ollama running
- [ ] Manual: launch TUI with no providers configured, verify wizard triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)