### PR TITLE
Implement RPCs, plugin system, and complete remaining gaps

### DIFF
--- a/cmd/ratchet/cmd_plugin.go
+++ b/cmd/ratchet/cmd_plugin.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/GoCodeAlone/ratchet-cli/internal/plugins"
 )
@@ -14,34 +17,43 @@ func handlePlugin(args []string) {
 	}
 	switch args[0] {
 	case "list":
-		names, err := plugins.List()
+		reg, err := plugins.Load()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}
-		if len(names) == 0 {
+		if len(reg.Plugins) == 0 {
 			fmt.Println("No plugins installed.")
 			return
 		}
-		for _, n := range names {
-			fmt.Println(n)
+		fmt.Printf("%-20s %-10s %s\n", "NAME", "VERSION", "SOURCE")
+		for name, entry := range reg.Plugins {
+			fmt.Printf("%-20s %-10s %s\n", name, entry.Version, entry.Source)
 		}
 	case "install":
 		if len(args) < 2 {
-			fmt.Println("Usage: ratchet plugin install <name>")
+			fmt.Println("Usage: ratchet plugin install <owner/repo or ./path>")
 			return
 		}
-		if err := plugins.Install(args[1]); err != nil {
+		src := args[1]
+		var err error
+		if isLocalPath(src) {
+			src = expandHome(src)
+			err = plugins.InstallFromLocal(src)
+		} else {
+			err = plugins.InstallFromGitHub(context.Background(), src)
+		}
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}
-		fmt.Printf("Installed plugin: %s\n", args[1])
+		fmt.Printf("Installed plugin: %s\n", src)
 	case "remove":
 		if len(args) < 2 {
 			fmt.Println("Usage: ratchet plugin remove <name>")
 			return
 		}
-		if err := plugins.Remove(args[1]); err != nil {
+		if err := plugins.Uninstall(args[1]); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}
@@ -49,4 +61,41 @@ func handlePlugin(args []string) {
 	default:
 		fmt.Printf("unknown plugin command: %s\n", args[0])
 	}
+}
+
+// expandHome replaces a leading ~ with the user's home directory.
+func expandHome(path string) string {
+	if !strings.HasPrefix(path, "~") {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	return filepath.Join(home, path[1:])
+}
+
+// isLocalPath returns true if src looks like a local filesystem path
+// rather than a GitHub owner/repo reference.
+func isLocalPath(src string) bool {
+	if len(src) == 0 {
+		return false
+	}
+	// Explicit relative/absolute paths
+	if src[0] == '.' || src[0] == '/' {
+		return true
+	}
+	// Home-relative paths
+	if strings.HasPrefix(src, "~") {
+		return true
+	}
+	// Windows absolute paths (e.g. C:\...)
+	if len(src) >= 2 && src[1] == ':' {
+		return true
+	}
+	// If it exists on disk, treat it as local
+	if _, err := os.Stat(src); err == nil {
+		return true
+	}
+	return false
 }

--- a/internal/daemon/engine.go
+++ b/internal/daemon/engine.go
@@ -9,10 +9,12 @@ import (
 
 	"path/filepath"
 
+	"github.com/GoCodeAlone/ratchet-cli/internal/agent"
 	"github.com/GoCodeAlone/ratchet-cli/internal/config"
 	"github.com/GoCodeAlone/ratchet-cli/internal/hooks"
 	"github.com/GoCodeAlone/ratchet-cli/internal/mcp"
 	"github.com/GoCodeAlone/ratchet-cli/internal/plugins"
+	"github.com/GoCodeAlone/ratchet-cli/internal/skills"
 	ratchetplugin "github.com/GoCodeAlone/workflow-plugin-agent/orchestrator"
 	"github.com/GoCodeAlone/workflow/secrets"
 	_ "modernc.org/sqlite"
@@ -30,6 +32,11 @@ type EngineContext struct {
 	ModelRouting     config.ModelRouting
 	Actors           *ActorManager
 	Hooks            *hooks.HookConfig
+	// Plugin-contributed capabilities
+	PluginSkills   []skills.Skill
+	PluginAgents   []agent.AgentDefinition
+	PluginCommands []plugins.Command
+	PluginDaemons  []*plugins.DaemonTool // stopped on Close()
 }
 
 func NewEngineContext(ctx context.Context, dbPath string) (*EngineContext, error) { //nolint:unparam
@@ -94,14 +101,23 @@ func NewEngineContext(ctx context.Context, dbPath string) (*EngineContext, error
 		}
 	}()
 
-	// Load external plugins from ~/.ratchet/plugins/
+	// Load external plugins from ~/.ratchet/plugins/ and wire capabilities.
 	pluginLoader := plugins.NewLoader(filepath.Join(DataDir(), "plugins"))
-	loaded, err := pluginLoader.LoadAll()
-	if err != nil {
-		log.Printf("warning: plugin loading: %v", err)
-	}
-	for _, p := range loaded {
-		log.Printf("loaded plugin: %s (%s)", p.Name, p.Path)
+	pluginResult, pluginErr := pluginLoader.LoadAll(ctx)
+	if pluginErr != nil {
+		log.Printf("warning: plugin loading: %v", pluginErr)
+	} else {
+		// Register plugin tools with the tool registry.
+		for _, t := range pluginResult.Tools {
+			ec.ToolRegistry.Register(t)
+		}
+		// Store skills, agents, commands for later query.
+		ec.PluginSkills = pluginResult.Skills
+		ec.PluginAgents = pluginResult.Agents
+		ec.PluginCommands = pluginResult.Commands
+		log.Printf("plugins: %d skills, %d agents, %d commands, %d tools loaded",
+			len(pluginResult.Skills), len(pluginResult.Agents),
+			len(pluginResult.Commands), len(pluginResult.Tools))
 	}
 
 	// Actor system (non-fatal on error; actors are optional middleware).
@@ -114,12 +130,27 @@ func NewEngineContext(ctx context.Context, dbPath string) (*EngineContext, error
 
 	// Hooks config (non-fatal; hooks are optional)
 	ec.Hooks, _ = hooks.Load("")
+	if ec.Hooks == nil {
+		ec.Hooks = &hooks.HookConfig{Hooks: make(map[hooks.Event][]hooks.Hook)}
+	}
+	// Merge plugin-contributed hooks.
+	if pluginErr == nil {
+		for event, hookList := range pluginResult.Hooks.Hooks {
+			ec.Hooks.Hooks[event] = append(ec.Hooks.Hooks[event], hookList...)
+		}
+	}
 
 	log.Println("engine context initialized")
 	return ec, nil
 }
 
 func (ec *EngineContext) Close() {
+	// Stop plugin daemon tools.
+	for _, d := range ec.PluginDaemons {
+		if err := d.Stop(); err != nil {
+			log.Printf("stop plugin daemon: %v", err)
+		}
+	}
 	if ec.Actors != nil {
 		_ = ec.Actors.Close(context.Background())
 	}

--- a/internal/mesh/remote_node.go
+++ b/internal/mesh/remote_node.go
@@ -59,6 +59,15 @@ func (n *RemoteNode) Run(ctx context.Context, task string, bb *Blackboard, inbox
 		return fmt.Errorf("remote node %s: open mesh stream at %s: %w", n.id, n.address, err)
 	}
 
+	// Send handshake so the server uses our node ID (not a random one).
+	if err := stream.Send(&pb.MeshEvent{
+		Event: &pb.MeshEvent_NodeRegistered{
+			NodeRegistered: &pb.RegisterNodeResp{NodeId: n.id},
+		},
+	}); err != nil {
+		return fmt.Errorf("remote node %s: send handshake to %s: %w", n.id, n.address, err)
+	}
+
 	// doneCh is closed when the remote signals task completion.
 	doneCh := make(chan struct{})
 

--- a/internal/mesh/remote_node_test.go
+++ b/internal/mesh/remote_node_test.go
@@ -68,6 +68,17 @@ func TestRemoteNode_DialsAndReceivesAgentMessage(t *testing.T) {
 		runErr <- node.Run(ctx, "test task", bb, inbox, outbox)
 	}()
 
+	// The node sends a NodeRegistered handshake immediately on connect.
+	// Drain it before checking for the forwarded inbox message.
+	select {
+	case ev := <-srv.received:
+		if ev.GetNodeRegistered() == nil {
+			t.Fatalf("expected initial NodeRegistered handshake, got %T", ev.Event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for NodeRegistered handshake")
+	}
+
 	// Send a message via the inbox to test forwarding.
 	inbox <- Message{From: "local", To: "remote", Content: "hello remote", Type: "task"}
 

--- a/internal/plugins/installer.go
+++ b/internal/plugins/installer.go
@@ -1,0 +1,234 @@
+package plugins
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// InstallFromGitHub downloads the latest release tarball from a GitHub repo
+// and installs it to ~/.ratchet/plugins/<name>/.
+// repo must be in "owner/name" format.
+func InstallFromGitHub(ctx context.Context, repo string) error {
+	parts := strings.SplitN(repo, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return fmt.Errorf("invalid repo format %q: expected owner/name", repo)
+	}
+	name := parts[1]
+
+	tmpDir, err := os.MkdirTemp("", "ratchet-plugin-*")
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	cmd := exec.CommandContext(ctx, "gh", "release", "download",
+		"--repo", repo,
+		"--pattern", "*.tar.gz",
+		"--dir", tmpDir,
+	)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("gh release download: %w", err)
+	}
+
+	// Find the downloaded tarball
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		return fmt.Errorf("read temp dir: %w", err)
+	}
+	var tarball string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tar.gz") {
+			tarball = filepath.Join(tmpDir, e.Name())
+			break
+		}
+	}
+	if tarball == "" {
+		return fmt.Errorf("no .tar.gz found in release download")
+	}
+
+	destDir := filepath.Join(pluginsDir(), name)
+	if err := extractTarGz(tarball, destDir); err != nil {
+		_ = os.RemoveAll(destDir)
+		return fmt.Errorf("extract tarball: %w", err)
+	}
+
+	m, err := LoadManifest(destDir)
+	if err != nil {
+		_ = os.RemoveAll(destDir)
+		return fmt.Errorf("verify manifest: %w", err)
+	}
+
+	reg, err := Load()
+	if err != nil {
+		return fmt.Errorf("load registry: %w", err)
+	}
+	return reg.Add(name, RegistryEntry{
+		Source:      "github:" + repo,
+		Version:     m.Version,
+		InstalledAt: time.Now(),
+		Path:        destDir,
+	})
+}
+
+// InstallFromLocal copies src to ~/.ratchet/plugins/<name>/ and registers it.
+// src must contain a valid plugin manifest.
+func InstallFromLocal(src string) error {
+	m, err := LoadManifest(src)
+	if err != nil {
+		return fmt.Errorf("verify manifest at %s: %w", src, err)
+	}
+
+	destDir := filepath.Join(pluginsDir(), m.Name)
+	// Remove any existing install to prevent stale files from a previous version.
+	_ = os.RemoveAll(destDir)
+	if err := copyDir(src, destDir); err != nil {
+		_ = os.RemoveAll(destDir) // clean up partial copy
+		return fmt.Errorf("copy plugin: %w", err)
+	}
+
+	reg, err := Load()
+	if err != nil {
+		return fmt.Errorf("load registry: %w", err)
+	}
+	abs, err := filepath.Abs(src)
+	if err != nil {
+		abs = src
+	}
+	return reg.Add(m.Name, RegistryEntry{
+		Source:      "local:" + abs,
+		Version:     m.Version,
+		InstalledAt: time.Now(),
+		Path:        destDir,
+	})
+}
+
+// Uninstall removes a plugin directory and its registry entry.
+func Uninstall(name string) error {
+	dir := filepath.Join(pluginsDir(), name)
+	if err := os.RemoveAll(dir); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove plugin dir: %w", err)
+	}
+	reg, err := Load()
+	if err != nil {
+		return fmt.Errorf("load registry: %w", err)
+	}
+	return reg.Remove(name)
+}
+
+// copyDir recursively copies src directory to dst.
+func copyDir(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		return copyFile(path, target)
+	})
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	return err
+}
+
+// extractTarGz extracts a .tar.gz archive to destDir.
+func extractTarGz(tarball, destDir string) error {
+	f, err := os.Open(tarball)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("gzip reader: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("tar read: %w", err)
+		}
+
+		// Strip leading path component (common in GitHub release tarballs)
+		parts := strings.SplitN(filepath.ToSlash(hdr.Name), "/", 2)
+		var rel string
+		if len(parts) == 2 {
+			rel = parts[1]
+		} else {
+			rel = hdr.Name
+		}
+		if rel == "" {
+			continue
+		}
+
+		target := filepath.Join(destDir, filepath.FromSlash(rel))
+		// Prevent path traversal
+		if !strings.HasPrefix(target, filepath.Clean(destDir)+string(os.PathSeparator)) {
+			return fmt.Errorf("invalid tar entry path: %s", hdr.Name)
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode))
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(out, tr); err != nil {
+				out.Close()
+				return err
+			}
+			out.Close()
+		}
+	}
+	return nil
+}

--- a/internal/plugins/installer_test.go
+++ b/internal/plugins/installer_test.go
@@ -1,0 +1,112 @@
+package plugins
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func setupPlugin(t *testing.T, name, version string) string {
+	t.Helper()
+	dir := t.TempDir()
+	manifest := `{"name":"` + name + `","version":"` + version + `","description":"test","author":{"name":"test"},"capabilities":{"skills":"./skills/"}}`
+	writeJSON(t, filepath.Join(dir, ".ratchet-plugin", "plugin.json"), manifest)
+	// Add a sample skill file so there's something to copy
+	if err := os.MkdirAll(filepath.Join(dir, "skills", "hello"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "skills", "hello", "SKILL.md"), []byte("# Hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestInstallFromLocal(t *testing.T) {
+	// Override plugins dir and registry for this test
+	src := setupPlugin(t, "my-plugin", "1.0.0")
+
+	pluginsBase := t.TempDir()
+	t.Setenv("HOME", pluginsBase) // affects pluginsDir() and registryPath()
+
+	if err := InstallFromLocal(src); err != nil {
+		t.Fatalf("InstallFromLocal: %v", err)
+	}
+
+	// Verify plugin directory was created
+	destDir := filepath.Join(pluginsBase, ".ratchet", "plugins", "my-plugin")
+	if _, err := os.Stat(destDir); err != nil {
+		t.Errorf("plugin dir not created: %v", err)
+	}
+
+	// Verify manifest is present at destination
+	if _, err := LoadManifest(destDir); err != nil {
+		t.Errorf("manifest not found at dest: %v", err)
+	}
+
+	// Verify registry entry
+	reg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, ok := reg.Get("my-plugin")
+	if !ok {
+		t.Fatal("expected registry entry for my-plugin")
+	}
+	if entry.Version != "1.0.0" {
+		t.Errorf("version = %q, want 1.0.0", entry.Version)
+	}
+	if entry.Path != destDir {
+		t.Errorf("path = %q, want %q", entry.Path, destDir)
+	}
+}
+
+func TestUninstall(t *testing.T) {
+	src := setupPlugin(t, "bye-plugin", "0.1.0")
+
+	pluginsBase := t.TempDir()
+	t.Setenv("HOME", pluginsBase)
+
+	if err := InstallFromLocal(src); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	if err := Uninstall("bye-plugin"); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+
+	destDir := filepath.Join(pluginsBase, ".ratchet", "plugins", "bye-plugin")
+	if _, err := os.Stat(destDir); !os.IsNotExist(err) {
+		t.Error("plugin dir should be removed after uninstall")
+	}
+
+	reg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := reg.Get("bye-plugin"); ok {
+		t.Error("registry entry should be removed after uninstall")
+	}
+}
+
+func TestInstallFromLocal_InvalidManifest(t *testing.T) {
+	dir := t.TempDir()
+	// No manifest file at all
+
+	pluginsBase := t.TempDir()
+	t.Setenv("HOME", pluginsBase)
+
+	err := InstallFromLocal(dir)
+	if err == nil {
+		t.Error("expected error for directory with no manifest")
+	}
+}
+
+func TestUninstall_NonExistent(t *testing.T) {
+	pluginsBase := t.TempDir()
+	t.Setenv("HOME", pluginsBase)
+
+	// Should not error if plugin doesn't exist
+	if err := Uninstall("ghost"); err != nil {
+		t.Errorf("unexpected error uninstalling non-existent plugin: %v", err)
+	}
+}

--- a/internal/plugins/integration_test.go
+++ b/internal/plugins/integration_test.go
@@ -1,0 +1,233 @@
+package plugins
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// buildPluginDir creates a complete plugin directory for integration testing.
+// It has a manifest, skill, agent, command, and exec tool (shell cat).
+func buildPluginDir(t *testing.T, name string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script tools not supported on Windows")
+	}
+	dir := t.TempDir()
+
+	// Manifest
+	manifest := map[string]any{
+		"name":        name,
+		"version":     "1.0.0",
+		"description": "Integration test plugin",
+		"author":      map[string]any{"name": "test"},
+		"capabilities": map[string]any{
+			"skills":   "./skills/",
+			"agents":   "./agents/",
+			"commands": "./commands/",
+			"tools":    "./tools/",
+		},
+	}
+	manifestData, _ := json.Marshal(manifest)
+	writeJSON(t, filepath.Join(dir, ".ratchet-plugin", "plugin.json"), string(manifestData))
+
+	// Skill
+	mustMkdir(t, filepath.Join(dir, "skills", "greet"))
+	mustWrite(t, filepath.Join(dir, "skills", "greet", "SKILL.md"), "# Greet\nSay hello.")
+
+	// Agent
+	mustMkdir(t, filepath.Join(dir, "agents"))
+	mustWrite(t, filepath.Join(dir, "agents", "helper.yaml"), "name: helper\nrole: assistant\nsystem_prompt: Help the user.\n")
+
+	// Command
+	mustMkdir(t, filepath.Join(dir, "commands"))
+	mustWrite(t, filepath.Join(dir, "commands", "greet.md"), "# /greet\nSay hello to the user.")
+
+	// Tool: echo_tool using exec protocol (cat echoes stdin)
+	mustMkdir(t, filepath.Join(dir, "tools", "echo_tool"))
+	toolDef := ToolDef{
+		Name:        "echo_tool",
+		Description: "echoes arguments",
+		Protocol:    "exec",
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"msg": map[string]any{"type": "string"}},
+		},
+	}
+	toolData, _ := json.Marshal(toolDef)
+	mustWrite(t, filepath.Join(dir, "tools", "echo_tool", "tool.json"), string(toolData))
+	mustWrite(t, filepath.Join(dir, "tools", "echo_tool", "echo_tool"), "#!/bin/sh\ncat\n")
+	if err := os.Chmod(filepath.Join(dir, "tools", "echo_tool", "echo_tool"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	return dir
+}
+
+func mustMkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestIntegration_LoadAllCapabilities verifies that LoadAll discovers all
+// capability types from a well-formed plugin directory.
+func TestIntegration_LoadAllCapabilities(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("integration tests use shell scripts, unsupported on Windows")
+	}
+	pluginsBase := t.TempDir()
+	src := buildPluginDir(t, "int-plugin")
+
+	// Place the plugin directory inside pluginsBase
+	dest := filepath.Join(pluginsBase, "int-plugin")
+	if err := copyDir(src, dest); err != nil {
+		t.Fatalf("copy plugin dir: %v", err)
+	}
+
+	l := NewLoader(pluginsBase)
+	result, err := l.LoadAll(context.Background())
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+
+	if len(result.Skills) != 1 {
+		t.Errorf("skills: got %d, want 1", len(result.Skills))
+	} else if result.Skills[0].Name != "greet" {
+		t.Errorf("skill name = %q, want greet", result.Skills[0].Name)
+	}
+
+	if len(result.Agents) != 1 {
+		t.Errorf("agents: got %d, want 1", len(result.Agents))
+	} else if result.Agents[0].Name != "helper" {
+		t.Errorf("agent name = %q, want helper", result.Agents[0].Name)
+	}
+
+	if len(result.Commands) != 1 {
+		t.Errorf("commands: got %d, want 1", len(result.Commands))
+	} else if result.Commands[0].Name != "greet" {
+		t.Errorf("command name = %q, want greet", result.Commands[0].Name)
+	}
+
+	if len(result.Tools) != 1 {
+		t.Errorf("tools: got %d, want 1", len(result.Tools))
+	} else if result.Tools[0].Name() != "echo_tool" {
+		t.Errorf("tool name = %q, want echo_tool", result.Tools[0].Name())
+	}
+}
+
+// TestIntegration_ExecuteTool verifies that a plugin tool can be executed
+// and returns a JSON result.
+func TestIntegration_ExecuteTool(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("integration tests use shell scripts, unsupported on Windows")
+	}
+	pluginsBase := t.TempDir()
+	src := buildPluginDir(t, "exec-plugin")
+	dest := filepath.Join(pluginsBase, "exec-plugin")
+	if err := copyDir(src, dest); err != nil {
+		t.Fatalf("copy plugin dir: %v", err)
+	}
+
+	l := NewLoader(pluginsBase)
+	result, err := l.LoadAll(context.Background())
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(result.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(result.Tools))
+	}
+
+	tool := result.Tools[0]
+	out, err := tool.Execute(context.Background(), map[string]any{"msg": "integration"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out == nil {
+		t.Error("expected non-nil output from tool execute")
+	}
+}
+
+// TestIntegration_InstallAndRemoveLifecycle tests the full install → verify → remove cycle.
+func TestIntegration_InstallAndRemoveLifecycle(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("integration tests use shell scripts, unsupported on Windows")
+	}
+	src := buildPluginDir(t, "lifecycle-plugin")
+
+	// Override home dir so registry and plugins dir are isolated.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	// Install from local
+	if err := InstallFromLocal(src); err != nil {
+		t.Fatalf("InstallFromLocal: %v", err)
+	}
+
+	// Verify plugin directory was created
+	destDir := filepath.Join(fakeHome, ".ratchet", "plugins", "lifecycle-plugin")
+	if _, err := os.Stat(destDir); err != nil {
+		t.Errorf("plugin dir not found after install: %v", err)
+	}
+
+	// Verify manifest is present
+	if _, err := LoadManifest(destDir); err != nil {
+		t.Errorf("manifest not found at installed path: %v", err)
+	}
+
+	// Verify registry entry
+	reg, err := Load()
+	if err != nil {
+		t.Fatalf("Load registry: %v", err)
+	}
+	entry, ok := reg.Get("lifecycle-plugin")
+	if !ok {
+		t.Fatal("expected registry entry for lifecycle-plugin")
+	}
+	if entry.Version != "1.0.0" {
+		t.Errorf("version = %q, want 1.0.0", entry.Version)
+	}
+
+	// LoadAll should find it
+	l := NewLoader(filepath.Join(fakeHome, ".ratchet", "plugins"))
+	loadResult, err := l.LoadAll(context.Background())
+	if err != nil {
+		t.Fatalf("LoadAll after install: %v", err)
+	}
+	if len(loadResult.Skills) == 0 {
+		t.Error("expected skills from installed plugin")
+	}
+
+	// Remove
+	if err := Uninstall("lifecycle-plugin"); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+
+	// Verify directory is gone
+	if _, err := os.Stat(destDir); !os.IsNotExist(err) {
+		t.Error("plugin dir should be removed after uninstall")
+	}
+
+	// Verify registry entry is gone
+	reg2, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := reg2.Get("lifecycle-plugin"); ok {
+		t.Error("registry entry should be removed after uninstall")
+	}
+}

--- a/internal/plugins/loader.go
+++ b/internal/plugins/loader.go
@@ -1,85 +1,357 @@
 package plugins
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/GoCodeAlone/ratchet-cli/internal/agent"
+	"github.com/GoCodeAlone/ratchet-cli/internal/hooks"
+	"github.com/GoCodeAlone/ratchet-cli/internal/skills"
+	"github.com/GoCodeAlone/workflow-plugin-agent/plugin"
 )
 
-// PluginInfo describes a discovered plugin binary.
-type PluginInfo struct {
-	Name string
-	Path string
+// Command represents a slash command contributed by a plugin.
+type Command struct {
+	Name    string // slash command name (derived from filename without extension)
+	Content string // full markdown content
+	Path    string
 }
 
-// Loader discovers and tracks external plugins from the plugins directory.
+// MCPServerSpec describes a single MCP server entry from .mcp.json.
+type MCPServerSpec struct {
+	Command string            `json:"command"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+}
+
+// MCPConfig holds all MCP server declarations from a plugin's .mcp.json.
+type MCPConfig struct {
+	PluginName string
+	PluginDir  string
+	Servers    map[string]MCPServerSpec `json:"mcpServers"`
+}
+
+// LoadResult aggregates all capabilities discovered across loaded plugins.
+type LoadResult struct {
+	Skills     []skills.Skill
+	Agents     []agent.AgentDefinition
+	Commands   []Command
+	Hooks      *hooks.HookConfig
+	Tools      []plugin.Tool
+	MCPConfigs []MCPConfig
+	// Daemons holds all started daemon processes so callers can stop them.
+	// Call StopDaemons() to cleanly shut them all down.
+	Daemons []*DaemonTool
+}
+
+// StopDaemons stops all daemon tool processes tracked by this LoadResult.
+func (r *LoadResult) StopDaemons() {
+	stopDaemons(r.Daemons)
+}
+
+// Loader discovers and loads plugins from a directory.
 type Loader struct {
 	pluginDir string
-	loaded    []PluginInfo
 }
 
+// NewLoader creates a Loader targeting pluginDir.
 func NewLoader(pluginDir string) *Loader {
 	return &Loader{pluginDir: pluginDir}
 }
 
+// pluginsDir returns the default plugin installation directory.
 func pluginsDir() string {
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, ".ratchet", "plugins")
 }
 
-// LoadAll discovers plugin binaries in the plugins directory.
-// Each executable file is treated as a plugin.
-func (l *Loader) LoadAll() ([]PluginInfo, error) {
+// LoadAll scans pluginDir for plugin directories, parses their manifests, and
+// returns all discovered capabilities aggregated in a LoadResult.
+// Daemon tools are started using ctx; cancel ctx to terminate them.
+func (l *Loader) LoadAll(ctx context.Context) (*LoadResult, error) {
 	entries, err := os.ReadDir(l.pluginDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return &LoadResult{Hooks: &hooks.HookConfig{Hooks: make(map[hooks.Event][]hooks.Hook)}}, nil
 		}
 		return nil, fmt.Errorf("read plugins dir: %w", err)
 	}
 
+	result := &LoadResult{
+		Hooks: &hooks.HookConfig{Hooks: make(map[hooks.Event][]hooks.Hook)},
+	}
+
 	for _, entry := range entries {
-		if entry.IsDir() {
+		if !entry.IsDir() {
 			continue
 		}
-		info, err := entry.Info()
-		if err != nil || info.Mode()&0111 == 0 {
-			continue // skip non-executable files
+		pluginDir := filepath.Join(l.pluginDir, entry.Name())
+		m, err := LoadManifest(pluginDir)
+		if err != nil {
+			// Not a plugin directory — skip silently.
+			continue
 		}
-		l.loaded = append(l.loaded, PluginInfo{
-			Name: entry.Name(),
-			Path: filepath.Join(l.pluginDir, entry.Name()),
-		})
+		if err := l.loadPlugin(ctx, pluginDir, m, result); err != nil {
+			return nil, fmt.Errorf("load plugin %s: %w", m.Name, err)
+		}
 	}
-	return l.loaded, nil
+	return result, nil
 }
 
-// Install downloads a plugin binary from the registry and places it in the plugins dir.
-func Install(name string) error {
-	return fmt.Errorf("plugin install not yet implemented")
+// loadPlugin loads a single plugin's capabilities into result.
+func (l *Loader) loadPlugin(ctx context.Context, pluginDir string, m *Manifest, result *LoadResult) error {
+	if m.Capabilities.Skills != "" {
+		s, err := loadSkills(filepath.Join(pluginDir, m.Capabilities.Skills))
+		if err != nil {
+			return fmt.Errorf("skills: %w", err)
+		}
+		result.Skills = append(result.Skills, s...)
+	}
+
+	if m.Capabilities.Agents != "" {
+		a, err := loadAgents(filepath.Join(pluginDir, m.Capabilities.Agents))
+		if err != nil {
+			return fmt.Errorf("agents: %w", err)
+		}
+		result.Agents = append(result.Agents, a...)
+	}
+
+	if m.Capabilities.Commands != "" {
+		c, err := loadCommands(filepath.Join(pluginDir, m.Capabilities.Commands))
+		if err != nil {
+			return fmt.Errorf("commands: %w", err)
+		}
+		result.Commands = append(result.Commands, c...)
+	}
+
+	if m.Capabilities.Hooks != "" {
+		hc, err := loadHooks(filepath.Join(pluginDir, m.Capabilities.Hooks))
+		if err != nil {
+			return fmt.Errorf("hooks: %w", err)
+		}
+		// Merge plugin hooks into result hooks.
+		for event, hookList := range hc.Hooks {
+			result.Hooks.Hooks[event] = append(result.Hooks.Hooks[event], hookList...)
+		}
+	}
+
+	if m.Capabilities.Tools != "" {
+		tools, daemons, err := loadTools(ctx, filepath.Join(pluginDir, m.Capabilities.Tools))
+		if err != nil {
+			return fmt.Errorf("tools: %w", err)
+		}
+		result.Tools = append(result.Tools, tools...)
+		result.Daemons = append(result.Daemons, daemons...)
+	}
+
+	if m.Capabilities.MCP != "" {
+		mc, err := loadMCPConfig(m.Name, pluginDir, filepath.Join(pluginDir, m.Capabilities.MCP))
+		if err != nil {
+			return fmt.Errorf("mcp: %w", err)
+		}
+		result.MCPConfigs = append(result.MCPConfigs, mc)
+	}
+
+	return nil
 }
 
-// Remove deletes a plugin binary.
-func Remove(name string) error {
-	path := filepath.Join(pluginsDir(), name)
-	return os.Remove(path)
-}
-
-// List returns names of installed plugins.
-func List() ([]string, error) {
-	dir := pluginsDir()
-	entries, err := os.ReadDir(dir)
+// loadSkills reads SKILL.md files from skill subdirectories.
+func loadSkills(skillsDir string) ([]skills.Skill, error) {
+	entries, err := os.ReadDir(skillsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	var names []string
+	var result []skills.Skill
 	for _, e := range entries {
 		if !e.IsDir() {
-			names = append(names, e.Name())
+			continue
+		}
+		skillFile := filepath.Join(skillsDir, e.Name(), "SKILL.md")
+		content, err := os.ReadFile(skillFile)
+		if err != nil {
+			continue // skip skill dirs without SKILL.md
+		}
+		result = append(result, skills.Skill{
+			Name:    e.Name(),
+			Path:    skillFile,
+			Content: string(content),
+		})
+	}
+	return result, nil
+}
+
+// loadAgents reads *.yaml agent definition files from agentsDir.
+func loadAgents(agentsDir string) ([]agent.AgentDefinition, error) {
+	entries, err := os.ReadDir(agentsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var result []agent.AgentDefinition
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		ext := filepath.Ext(e.Name())
+		if ext != ".yaml" && ext != ".yml" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(agentsDir, e.Name()))
+		if err != nil {
+			continue
+		}
+		var def agent.AgentDefinition
+		if err := yaml.Unmarshal(data, &def); err != nil {
+			continue
+		}
+		if def.Name == "" {
+			def.Name = strings.TrimSuffix(e.Name(), ext)
+		}
+		result = append(result, def)
+	}
+	return result, nil
+}
+
+// loadCommands reads *.md command files from commandsDir.
+func loadCommands(commandsDir string) ([]Command, error) {
+	entries, err := os.ReadDir(commandsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var result []Command
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if filepath.Ext(e.Name()) != ".md" {
+			continue
+		}
+		path := filepath.Join(commandsDir, e.Name())
+		content, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		name := strings.TrimSuffix(e.Name(), ".md")
+		result = append(result, Command{
+			Name:    name,
+			Content: string(content),
+			Path:    path,
+		})
+	}
+	return result, nil
+}
+
+// loadHooks parses a hooks JSON/YAML file into a HookConfig.
+func loadHooks(hooksFile string) (*hooks.HookConfig, error) {
+	data, err := os.ReadFile(hooksFile)
+	if err != nil {
+		return nil, err
+	}
+	var hc hooks.HookConfig
+	// yaml.Unmarshal handles JSON too (JSON is a subset of YAML).
+	if err := yaml.Unmarshal(data, &hc); err != nil {
+		return nil, fmt.Errorf("parse hooks: %w", err)
+	}
+	if hc.Hooks == nil {
+		hc.Hooks = make(map[hooks.Event][]hooks.Hook)
+	}
+	return &hc, nil
+}
+
+// loadTools scans toolsDir for tool subdirectories and creates ExecTool or
+// DaemonTool instances based on the protocol declared in tool.json.
+// It returns all tool references and the started daemon processes separately
+// so callers can stop the daemons when done.
+func loadTools(ctx context.Context, toolsDir string) ([]plugin.Tool, []*DaemonTool, error) {
+	entries, err := os.ReadDir(toolsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, nil
+		}
+		return nil, nil, err
+	}
+	var result []plugin.Tool
+	var startedDaemons []*DaemonTool
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		toolDir := filepath.Join(toolsDir, e.Name())
+		defData, err := os.ReadFile(filepath.Join(toolDir, "tool.json"))
+		if err != nil {
+			continue // not a tool directory
+		}
+		var def ToolDef
+		if err := json.Unmarshal(defData, &def); err != nil {
+			log.Printf("plugins: skipping %s: parse tool.json: %v", e.Name(), err)
+			continue
+		}
+		if def.Name == "" {
+			log.Printf("plugins: skipping %s: tool.json missing 'name' field", e.Name())
+			continue
+		}
+
+		switch def.Protocol {
+		case "daemon":
+			binPath, err := findBinary(toolDir, def.Name)
+			if err != nil {
+				stopDaemons(startedDaemons)
+				return nil, nil, fmt.Errorf("tool %s: %w", def.Name, err)
+			}
+			daemon, err := StartDaemon(ctx, binPath)
+			if err != nil {
+				stopDaemons(startedDaemons)
+				return nil, nil, fmt.Errorf("start daemon %s: %w", def.Name, err)
+			}
+			startedDaemons = append(startedDaemons, daemon)
+			for _, d := range daemon.Defs() {
+				result = append(result, NewDaemonToolRef(daemon, d))
+			}
+		default: // "exec" or unspecified
+			t, err := LoadExecTool(toolDir)
+			if err != nil {
+				stopDaemons(startedDaemons)
+				return nil, nil, fmt.Errorf("tool %s: %w", def.Name, err)
+			}
+			result = append(result, t)
 		}
 	}
-	return names, nil
+	return result, startedDaemons, nil
+}
+
+// stopDaemons stops all daemon tools in the slice (used for cleanup on error).
+func stopDaemons(daemons []*DaemonTool) {
+	for _, d := range daemons {
+		_ = d.Stop()
+	}
+}
+
+// loadMCPConfig reads a .mcp.json file and returns an MCPConfig.
+func loadMCPConfig(pluginName, pluginDir, mcpFile string) (MCPConfig, error) {
+	data, err := os.ReadFile(mcpFile)
+	if err != nil {
+		return MCPConfig{}, err
+	}
+	var mc MCPConfig
+	if err := json.Unmarshal(data, &mc); err != nil {
+		return MCPConfig{}, fmt.Errorf("parse .mcp.json: %w", err)
+	}
+	mc.PluginName = pluginName
+	mc.PluginDir = pluginDir
+	return mc, nil
 }

--- a/internal/plugins/loader_test.go
+++ b/internal/plugins/loader_test.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,52 +9,117 @@ import (
 
 func TestLoadAllEmpty(t *testing.T) {
 	l := NewLoader(t.TempDir())
-	plugins, err := l.LoadAll()
+	result, err := l.LoadAll(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(plugins) != 0 {
-		t.Errorf("expected 0 plugins, got %d", len(plugins))
+	if len(result.Skills) != 0 {
+		t.Errorf("expected 0 skills, got %d", len(result.Skills))
+	}
+	if len(result.Tools) != 0 {
+		t.Errorf("expected 0 tools, got %d", len(result.Tools))
 	}
 }
 
 func TestLoadAllMissing(t *testing.T) {
 	l := NewLoader(filepath.Join(t.TempDir(), "nonexistent"))
-	plugins, err := l.LoadAll()
+	result, err := l.LoadAll(context.Background())
 	if err != nil {
 		t.Fatalf("expected no error for missing dir: %v", err)
 	}
-	if len(plugins) != 0 {
-		t.Errorf("expected 0 plugins, got %d", len(plugins))
+	if result == nil {
+		t.Fatal("expected non-nil result")
 	}
 }
 
-func TestLoadAllExecutable(t *testing.T) {
+func TestLoadAllSkipsNonPluginDirs(t *testing.T) {
 	dir := t.TempDir()
 
-	// Create an executable file
-	execPath := filepath.Join(dir, "my-plugin")
-	if err := os.WriteFile(execPath, []byte("#!/bin/sh\necho hi"), 0755); err != nil {
+	// Create a directory that has no manifest (should be silently skipped)
+	notAPlugin := filepath.Join(dir, "not-a-plugin")
+	if err := os.MkdirAll(notAPlugin, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	// Create a non-executable file (should be skipped)
-	nonExecPath := filepath.Join(dir, "readme.txt")
-	if err := os.WriteFile(nonExecPath, []byte("docs"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(notAPlugin, "readme.txt"), []byte("docs"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	l := NewLoader(dir)
-	plugins, err := l.LoadAll()
+	result, err := l.LoadAll(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(plugins) != 1 {
-		t.Errorf("expected 1 plugin, got %d", len(plugins))
+	if len(result.Skills) != 0 || len(result.Agents) != 0 || len(result.Tools) != 0 {
+		t.Error("expected no capabilities from non-plugin directory")
 	}
-	if plugins[0].Name != "my-plugin" {
-		t.Errorf("expected name 'my-plugin', got %s", plugins[0].Name)
+}
+
+func TestLoadAllSkillsAndAgents(t *testing.T) {
+	pluginsBase := t.TempDir()
+
+	// Build a plugin with skills and agents
+	pluginDir := filepath.Join(pluginsBase, "my-plugin")
+	manifest := `{"name":"my-plugin","version":"1.0.0","description":"test","author":{"name":"test"},"capabilities":{"skills":"./skills/","agents":"./agents/"}}`
+	writeJSON(t, filepath.Join(pluginDir, ".ratchet-plugin", "plugin.json"), manifest)
+
+	// Add a skill
+	if err := os.MkdirAll(filepath.Join(pluginDir, "skills", "hello"), 0o755); err != nil {
+		t.Fatal(err)
 	}
-	if plugins[0].Path != execPath {
-		t.Errorf("expected path %s, got %s", execPath, plugins[0].Path)
+	if err := os.WriteFile(filepath.Join(pluginDir, "skills", "hello", "SKILL.md"), []byte("# Hello skill"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add an agent YAML
+	if err := os.MkdirAll(filepath.Join(pluginDir, "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	agentYAML := "name: reviewer\nrole: code reviewer\nsystem_prompt: Review code carefully.\n"
+	if err := os.WriteFile(filepath.Join(pluginDir, "agents", "reviewer.yaml"), []byte(agentYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	l := NewLoader(pluginsBase)
+	result, err := l.LoadAll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Skills) != 1 {
+		t.Errorf("expected 1 skill, got %d", len(result.Skills))
+	} else if result.Skills[0].Name != "hello" {
+		t.Errorf("skill name = %q, want %q", result.Skills[0].Name, "hello")
+	}
+
+	if len(result.Agents) != 1 {
+		t.Errorf("expected 1 agent, got %d", len(result.Agents))
+	} else if result.Agents[0].Name != "reviewer" {
+		t.Errorf("agent name = %q, want %q", result.Agents[0].Name, "reviewer")
+	}
+}
+
+func TestLoadAllCommands(t *testing.T) {
+	pluginsBase := t.TempDir()
+	pluginDir := filepath.Join(pluginsBase, "cmd-plugin")
+	manifest := `{"name":"cmd-plugin","version":"1.0.0","description":"test","author":{"name":"test"},"capabilities":{"commands":"./commands/"}}`
+	writeJSON(t, filepath.Join(pluginDir, ".ratchet-plugin", "plugin.json"), manifest)
+
+	if err := os.MkdirAll(filepath.Join(pluginDir, "commands"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "commands", "deploy.md"), []byte("# Deploy\nDeploy the app."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	l := NewLoader(pluginsBase)
+	result, err := l.LoadAll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Commands) != 1 {
+		t.Errorf("expected 1 command, got %d", len(result.Commands))
+	} else if result.Commands[0].Name != "deploy" {
+		t.Errorf("command name = %q, want %q", result.Commands[0].Name, "deploy")
 	}
 }

--- a/internal/plugins/manifest.go
+++ b/internal/plugins/manifest.go
@@ -1,0 +1,64 @@
+package plugins
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Manifest represents a plugin's plugin.json manifest.
+type Manifest struct {
+	Name         string       `json:"name"`
+	Version      string       `json:"version"`
+	Description  string       `json:"description"`
+	Author       Author       `json:"author"`
+	Capabilities Capabilities `json:"capabilities"`
+}
+
+// Author holds plugin author metadata.
+type Author struct {
+	Name  string `json:"name"`
+	Email string `json:"email,omitempty"`
+}
+
+// Capabilities declares which capability directories/files a plugin provides.
+type Capabilities struct {
+	Skills   string `json:"skills,omitempty"`   // relative dir path
+	Agents   string `json:"agents,omitempty"`   // relative dir path
+	Commands string `json:"commands,omitempty"` // relative dir path
+	Tools    string `json:"tools,omitempty"`    // relative dir path
+	Hooks    string `json:"hooks,omitempty"`    // relative file path
+	MCP      string `json:"mcp,omitempty"`      // relative file path
+}
+
+// manifestPaths lists manifest locations in preference order.
+var manifestPaths = []string{
+	filepath.Join(".ratchet-plugin", "plugin.json"),
+	filepath.Join(".claude-plugin", "plugin.json"),
+}
+
+// LoadManifest reads a plugin manifest from pluginDir.
+// It tries .ratchet-plugin/plugin.json first, then .claude-plugin/plugin.json.
+func LoadManifest(pluginDir string) (*Manifest, error) {
+	for _, rel := range manifestPaths {
+		path := filepath.Join(pluginDir, rel)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, fmt.Errorf("read manifest %s: %w", path, err)
+		}
+		var m Manifest
+		if err := json.Unmarshal(data, &m); err != nil {
+			return nil, fmt.Errorf("parse manifest %s: %w", path, err)
+		}
+		if m.Name == "" {
+			return nil, fmt.Errorf("manifest %s: 'name' field is required", path)
+		}
+		return &m, nil
+	}
+	return nil, fmt.Errorf("no manifest found in %s (tried .ratchet-plugin/plugin.json, .claude-plugin/plugin.json)", pluginDir)
+}

--- a/internal/plugins/manifest_test.go
+++ b/internal/plugins/manifest_test.go
@@ -1,0 +1,116 @@
+package plugins
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeJSON(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const validManifestJSON = `{
+	"name": "test-plugin",
+	"version": "1.0.0",
+	"description": "A test plugin",
+	"author": {"name": "GoCodeAlone", "email": "test@example.com"},
+	"capabilities": {
+		"skills": "./skills/",
+		"agents": "./agents/",
+		"commands": "./commands/",
+		"tools": "./tools/",
+		"hooks": "./hooks/hooks.json",
+		"mcp": "./.mcp.json"
+	}
+}`
+
+func TestLoadManifest_Valid(t *testing.T) {
+	dir := t.TempDir()
+	writeJSON(t, filepath.Join(dir, ".ratchet-plugin", "plugin.json"), validManifestJSON)
+
+	m, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Name != "test-plugin" {
+		t.Errorf("name = %q, want %q", m.Name, "test-plugin")
+	}
+	if m.Version != "1.0.0" {
+		t.Errorf("version = %q, want %q", m.Version, "1.0.0")
+	}
+	if m.Author.Name != "GoCodeAlone" {
+		t.Errorf("author = %q, want %q", m.Author.Name, "GoCodeAlone")
+	}
+	if m.Capabilities.Skills != "./skills/" {
+		t.Errorf("skills = %q, want %q", m.Capabilities.Skills, "./skills/")
+	}
+	if m.Capabilities.MCP != "./.mcp.json" {
+		t.Errorf("mcp = %q, want %q", m.Capabilities.MCP, "./.mcp.json")
+	}
+}
+
+func TestLoadManifest_MissingManifest(t *testing.T) {
+	dir := t.TempDir()
+	_, err := LoadManifest(dir)
+	if err == nil {
+		t.Fatal("expected error for missing manifest, got nil")
+	}
+}
+
+func TestLoadManifest_ClaudePluginFallback(t *testing.T) {
+	dir := t.TempDir()
+	// Only write .claude-plugin/plugin.json, not .ratchet-plugin/plugin.json
+	writeJSON(t, filepath.Join(dir, ".claude-plugin", "plugin.json"), validManifestJSON)
+
+	m, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Name != "test-plugin" {
+		t.Errorf("name = %q, want %q", m.Name, "test-plugin")
+	}
+}
+
+func TestLoadManifest_RatchetPluginPreferredOverClaude(t *testing.T) {
+	dir := t.TempDir()
+	ratchetJSON := `{"name":"ratchet-plugin","version":"2.0.0","description":"ratchet","author":{"name":"test"},"capabilities":{}}`
+	claudeJSON := `{"name":"claude-plugin","version":"1.0.0","description":"claude","author":{"name":"test"},"capabilities":{}}`
+
+	writeJSON(t, filepath.Join(dir, ".ratchet-plugin", "plugin.json"), ratchetJSON)
+	writeJSON(t, filepath.Join(dir, ".claude-plugin", "plugin.json"), claudeJSON)
+
+	m, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Name != "ratchet-plugin" {
+		t.Errorf("expected ratchet-plugin to take precedence, got %q", m.Name)
+	}
+}
+
+func TestLoadManifest_PartialCapabilities(t *testing.T) {
+	dir := t.TempDir()
+	partial := `{"name":"partial","version":"0.1.0","description":"partial","author":{"name":"test"},"capabilities":{"skills":"./skills/"}}`
+	writeJSON(t, filepath.Join(dir, ".ratchet-plugin", "plugin.json"), partial)
+
+	m, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Capabilities.Skills != "./skills/" {
+		t.Errorf("skills = %q, want %q", m.Capabilities.Skills, "./skills/")
+	}
+	if m.Capabilities.Tools != "" {
+		t.Errorf("tools should be empty, got %q", m.Capabilities.Tools)
+	}
+	if m.Capabilities.MCP != "" {
+		t.Errorf("mcp should be empty, got %q", m.Capabilities.MCP)
+	}
+}

--- a/internal/plugins/registry.go
+++ b/internal/plugins/registry.go
@@ -1,0 +1,91 @@
+package plugins
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// RegistryEntry records an installed plugin.
+type RegistryEntry struct {
+	Source      string    `json:"source"`       // "github:org/repo" or "local:/path"
+	Version     string    `json:"version"`
+	InstalledAt time.Time `json:"installed_at"`
+	Path        string    `json:"path"`
+}
+
+// Registry tracks installed plugins in ~/.ratchet/plugins/registry.json.
+type Registry struct {
+	Plugins  map[string]RegistryEntry `json:"plugins"`
+	filePath string
+}
+
+// registryPath returns the default registry file path.
+func registryPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".ratchet", "plugins", "registry.json")
+}
+
+// Load reads the registry from disk. Returns an empty registry if the file doesn't exist.
+func Load() (*Registry, error) {
+	return LoadFrom(registryPath())
+}
+
+// LoadFrom reads the registry from a specific path.
+func LoadFrom(path string) (*Registry, error) {
+	r := &Registry{
+		Plugins:  make(map[string]RegistryEntry),
+		filePath: path,
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return r, nil
+		}
+		return nil, fmt.Errorf("read registry: %w", err)
+	}
+	if err := json.Unmarshal(data, r); err != nil {
+		return nil, fmt.Errorf("parse registry: %w", err)
+	}
+	r.filePath = path
+	if r.Plugins == nil {
+		r.Plugins = make(map[string]RegistryEntry)
+	}
+	return r, nil
+}
+
+// Save writes the registry to disk.
+func (r *Registry) Save() error {
+	if err := os.MkdirAll(filepath.Dir(r.filePath), 0o755); err != nil {
+		return fmt.Errorf("create registry dir: %w", err)
+	}
+	data, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal registry: %w", err)
+	}
+	if err := os.WriteFile(r.filePath, data, 0o644); err != nil {
+		return fmt.Errorf("write registry: %w", err)
+	}
+	return nil
+}
+
+// Add inserts or replaces a plugin entry and saves.
+func (r *Registry) Add(name string, entry RegistryEntry) error {
+	r.Plugins[name] = entry
+	return r.Save()
+}
+
+// Remove deletes a plugin entry and saves. Returns nil if the entry doesn't exist.
+func (r *Registry) Remove(name string) error {
+	delete(r.Plugins, name)
+	return r.Save()
+}
+
+// Get retrieves a plugin entry by name.
+func (r *Registry) Get(name string) (RegistryEntry, bool) {
+	entry, ok := r.Plugins[name]
+	return entry, ok
+}

--- a/internal/plugins/registry_test.go
+++ b/internal/plugins/registry_test.go
@@ -1,0 +1,97 @@
+package plugins
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRegistry_LoadSaveRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "registry.json")
+
+	r, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom empty: %v", err)
+	}
+	if len(r.Plugins) != 0 {
+		t.Fatalf("expected empty registry, got %d plugins", len(r.Plugins))
+	}
+
+	entry := RegistryEntry{
+		Source:      "github:GoCodeAlone/my-plugin",
+		Version:     "1.0.0",
+		InstalledAt: time.Now().Truncate(time.Second),
+		Path:        "/home/user/.ratchet/plugins/my-plugin",
+	}
+	if err := r.Add("my-plugin", entry); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	r2, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom after save: %v", err)
+	}
+	got, ok := r2.Get("my-plugin")
+	if !ok {
+		t.Fatal("expected my-plugin in reloaded registry")
+	}
+	if got.Source != entry.Source {
+		t.Errorf("source = %q, want %q", got.Source, entry.Source)
+	}
+	if got.Version != entry.Version {
+		t.Errorf("version = %q, want %q", got.Version, entry.Version)
+	}
+}
+
+func TestRegistry_AddRemove(t *testing.T) {
+	dir := t.TempDir()
+	r, err := LoadFrom(filepath.Join(dir, "registry.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.Add("plugin-a", RegistryEntry{Source: "local:/tmp/a", Version: "0.1.0"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Add("plugin-b", RegistryEntry{Source: "local:/tmp/b", Version: "0.2.0"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Plugins) != 2 {
+		t.Fatalf("expected 2 plugins, got %d", len(r.Plugins))
+	}
+
+	if err := r.Remove("plugin-a"); err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Plugins) != 1 {
+		t.Fatalf("expected 1 plugin after remove, got %d", len(r.Plugins))
+	}
+	if _, ok := r.Get("plugin-a"); ok {
+		t.Error("plugin-a should not exist after remove")
+	}
+}
+
+func TestRegistry_GetMissing(t *testing.T) {
+	dir := t.TempDir()
+	r, err := LoadFrom(filepath.Join(dir, "registry.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, ok := r.Get("nonexistent")
+	if ok {
+		t.Error("expected false for missing plugin")
+	}
+}
+
+func TestRegistry_RemoveMissing(t *testing.T) {
+	dir := t.TempDir()
+	r, err := LoadFrom(filepath.Join(dir, "registry.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Remove of non-existent entry should not error
+	if err := r.Remove("ghost"); err != nil {
+		t.Errorf("unexpected error removing missing plugin: %v", err)
+	}
+}

--- a/internal/plugins/tool_daemon.go
+++ b/internal/plugins/tool_daemon.go
@@ -1,0 +1,267 @@
+package plugins
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/GoCodeAlone/workflow-plugin-agent/provider"
+)
+
+// daemonStopTimeout is the time to wait for a daemon process to exit cleanly.
+const daemonStopTimeout = 5 * time.Second
+
+// jsonrpcRequest is a JSON-RPC 2.0 request envelope.
+type jsonrpcRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      int    `json:"id"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
+// jsonrpcResponse is a JSON-RPC 2.0 response envelope.
+type jsonrpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int             `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *jsonrpcError   `json:"error,omitempty"`
+}
+
+// jsonrpcError represents a JSON-RPC 2.0 error object.
+type jsonrpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (e *jsonrpcError) Error() string {
+	return fmt.Sprintf("json-rpc error %d: %s", e.Code, e.Message)
+}
+
+// initializeResult is the expected shape of the "initialize" response's result.
+type initializeResult struct {
+	Protocol string    `json:"protocol"`
+	Tools    []ToolDef `json:"tools"`
+}
+
+// callParams is the params for a "call" request.
+type callParams struct {
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments"`
+}
+
+// DaemonTool manages a long-running plugin process that handles multiple tool
+// calls over its lifetime using JSON-RPC 2.0 over stdin/stdout.
+type DaemonTool struct {
+	binPath  string
+	cmd      *exec.Cmd
+	stdin    io.WriteCloser
+	stdout   *bufio.Reader
+	mu       sync.Mutex
+	nextID   atomic.Int64
+	defs     []ToolDef
+	waitOnce sync.Once
+	waitErr  error
+}
+
+// StartDaemon launches the daemon binary, performs the initialize handshake,
+// and returns a ready DaemonTool.
+func StartDaemon(ctx context.Context, binPath string) (*DaemonTool, error) {
+	cmd := exec.CommandContext(ctx, binPath)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdin pipe: %w", err)
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		stdin.Close()
+		return nil, fmt.Errorf("stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		stdin.Close()
+		return nil, fmt.Errorf("start daemon %s: %w", binPath, err)
+	}
+
+	d := &DaemonTool{
+		binPath: binPath,
+		cmd:     cmd,
+		stdin:   stdin,
+		stdout:  bufio.NewReader(stdoutPipe),
+	}
+
+	if err := d.initialize(); err != nil {
+		_ = stdin.Close()
+		_ = cmd.Process.Kill()
+		_ = d.wait() // reap zombie exactly once
+		return nil, fmt.Errorf("initialize daemon: %w", err)
+	}
+	return d, nil
+}
+
+// initialize sends the JSON-RPC initialize request and reads the tool list.
+func (d *DaemonTool) initialize() error {
+	id := int(d.nextID.Add(1))
+	req := jsonrpcRequest{
+		JSONRPC: "2.0",
+		ID:      id,
+		Method:  "initialize",
+		Params:  map[string]any{},
+	}
+	resp, err := d.roundTrip(req)
+	if err != nil {
+		return err
+	}
+	if resp.Error != nil {
+		return resp.Error
+	}
+
+	var result initializeResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		return fmt.Errorf("parse initialize result: %w", err)
+	}
+	d.defs = result.Tools
+	return nil
+}
+
+// roundTrip sends a JSON-RPC request and reads a response. Caller must hold mu.
+func (d *DaemonTool) roundTrip(req jsonrpcRequest) (*jsonrpcResponse, error) {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	data = append(data, '\n')
+
+	if _, err := d.stdin.Write(data); err != nil {
+		return nil, fmt.Errorf("write request: %w", err)
+	}
+
+	line, err := d.stdout.ReadBytes('\n')
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	var resp jsonrpcResponse
+	if err := json.Unmarshal(line, &resp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	if resp.ID != req.ID {
+		return nil, fmt.Errorf("response ID mismatch: got %d want %d", resp.ID, req.ID)
+	}
+	return &resp, nil
+}
+
+// wait reaps the child process exactly once and caches the error.
+func (d *DaemonTool) wait() error {
+	d.waitOnce.Do(func() { d.waitErr = d.cmd.Wait() })
+	return d.waitErr
+}
+
+// Call invokes a named tool on the daemon. It is goroutine-safe.
+func (d *DaemonTool) Call(ctx context.Context, name string, args map[string]any) (any, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	id := int(d.nextID.Add(1))
+	req := jsonrpcRequest{
+		JSONRPC: "2.0",
+		ID:      id,
+		Method:  "call",
+		Params:  callParams{Name: name, Arguments: args},
+	}
+
+	// Honour context cancellation while holding the lock.
+	type result struct {
+		resp *jsonrpcResponse
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		resp, err := d.roundTrip(req)
+		ch <- result{resp, err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		// Context cancelled while I/O is in flight. The goroutine is blocked
+		// on stdin/stdout and will corrupt the JSON-RPC stream for the next call.
+		// Kill the daemon to prevent interleaved responses, then reap via wait().
+		// wait() uses sync.Once so it's safe even if Stop() is called concurrently.
+		_ = d.cmd.Process.Kill()
+		_ = d.wait()
+		return nil, ctx.Err()
+	case r := <-ch:
+		if r.err != nil {
+			return nil, r.err
+		}
+		if r.resp.Error != nil {
+			return nil, r.resp.Error
+		}
+		var val any
+		if err := json.Unmarshal(r.resp.Result, &val); err != nil {
+			return nil, fmt.Errorf("parse call result: %w", err)
+		}
+		return val, nil
+	}
+}
+
+// Defs returns the tool definitions declared by the daemon at initialize time.
+func (d *DaemonTool) Defs() []ToolDef { return d.defs }
+
+// Stop gracefully shuts down the daemon: closes stdin, waits for exit with a
+// timeout, then kills if necessary.
+func (d *DaemonTool) Stop() error {
+	_ = d.stdin.Close()
+
+	done := make(chan error, 1)
+	go func() { done <- d.wait() }()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(daemonStopTimeout):
+		_ = d.cmd.Process.Kill()
+		return <-done
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DaemonToolRef — implements plugin.Tool for a single tool within a daemon
+// ---------------------------------------------------------------------------
+
+// DaemonToolRef wraps a single named tool exposed by a DaemonTool.
+type DaemonToolRef struct {
+	daemon *DaemonTool
+	def    ToolDef
+}
+
+// NewDaemonToolRef creates a DaemonToolRef for the named tool.
+func NewDaemonToolRef(daemon *DaemonTool, def ToolDef) *DaemonToolRef {
+	return &DaemonToolRef{daemon: daemon, def: def}
+}
+
+// Name implements plugin.Tool.
+func (r *DaemonToolRef) Name() string { return r.def.Name }
+
+// Description implements plugin.Tool.
+func (r *DaemonToolRef) Description() string { return r.def.Description }
+
+// Definition implements plugin.Tool.
+func (r *DaemonToolRef) Definition() provider.ToolDef {
+	return provider.ToolDef{
+		Name:        r.def.Name,
+		Description: r.def.Description,
+		Parameters:  r.def.Parameters,
+	}
+}
+
+// Execute implements plugin.Tool by delegating to the parent daemon.
+func (r *DaemonToolRef) Execute(ctx context.Context, args map[string]any) (any, error) {
+	return r.daemon.Call(ctx, r.def.Name, args)
+}

--- a/internal/plugins/tool_daemon_test.go
+++ b/internal/plugins/tool_daemon_test.go
@@ -1,0 +1,222 @@
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// buildTestDaemon compiles the testdata daemon helper and returns its path.
+func buildTestDaemon(t *testing.T) string {
+	t.Helper()
+
+	// Write the daemon source into a temp dir and compile it.
+	src := `package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type request struct {
+	JSONRPC string          ` + "`json:\"jsonrpc\"`" + `
+	ID      int             ` + "`json:\"id\"`" + `
+	Method  string          ` + "`json:\"method\"`" + `
+	Params  json.RawMessage ` + "`json:\"params,omitempty\"`" + `
+}
+
+type response struct {
+	JSONRPC string ` + "`json:\"jsonrpc\"`" + `
+	ID      int    ` + "`json:\"id\"`" + `
+	Result  any    ` + "`json:\"result,omitempty\"`" + `
+}
+
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+	enc := json.NewEncoder(os.Stdout)
+
+	for scanner.Scan() {
+		var req request
+		if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+			fmt.Fprintf(os.Stderr, "parse error: %v\n", err)
+			continue
+		}
+
+		switch req.Method {
+		case "initialize":
+			enc.Encode(response{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Result: map[string]any{
+					"protocol": "daemon",
+					"tools": []map[string]any{
+						{
+							"name":        "greet",
+							"description": "returns a greeting",
+							"protocol":    "daemon",
+							"parameters": map[string]any{
+								"type": "object",
+								"properties": map[string]any{
+									"name": map[string]any{"type": "string"},
+								},
+							},
+						},
+					},
+				},
+			})
+		case "call":
+			var params struct {
+				Name      string         ` + "`json:\"name\"`" + `
+				Arguments map[string]any ` + "`json:\"arguments\"`" + `
+			}
+			json.Unmarshal(req.Params, &params)
+			var greeting string
+			if n, ok := params.Arguments["name"].(string); ok && n != "" {
+				greeting = "Hello, " + n + "!"
+			} else {
+				greeting = "Hello!"
+			}
+			enc.Encode(response{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Result:  map[string]any{"greeting": greeting},
+			})
+		default:
+			fmt.Fprintf(os.Stderr, "unknown method: %s\n", req.Method)
+		}
+	}
+}
+`
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "main.go")
+	if err := os.WriteFile(srcFile, []byte(src), 0644); err != nil {
+		t.Fatalf("write daemon source: %v", err)
+	}
+
+	binName := "test_daemon"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	binPath := filepath.Join(srcDir, binName)
+
+	cmd := exec.Command("go", "build", "-o", binPath, srcFile)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("compile test daemon: %v\n%s", err, out)
+	}
+	return binPath
+}
+
+func TestDaemonTool_LifecycleAndCall(t *testing.T) {
+	binPath := buildTestDaemon(t)
+
+	ctx := context.Background()
+	daemon, err := StartDaemon(ctx, binPath)
+	if err != nil {
+		t.Fatalf("StartDaemon: %v", err)
+	}
+	t.Cleanup(func() { _ = daemon.Stop() })
+
+	// Verify defs discovered during initialize.
+	defs := daemon.Defs()
+	if len(defs) != 1 {
+		t.Fatalf("expected 1 tool def, got %d", len(defs))
+	}
+	if defs[0].Name != "greet" {
+		t.Errorf("defs[0].Name = %q, want greet", defs[0].Name)
+	}
+
+	// Call the greet tool.
+	result, err := daemon.Call(ctx, "greet", map[string]any{"name": "World"})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	got, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type = %T", result)
+	}
+	if got["greeting"] != "Hello, World!" {
+		t.Errorf("greeting = %v, want Hello, World!", got["greeting"])
+	}
+}
+
+func TestDaemonTool_MultipleCallsSerialised(t *testing.T) {
+	binPath := buildTestDaemon(t)
+
+	daemon, err := StartDaemon(context.Background(), binPath)
+	if err != nil {
+		t.Fatalf("StartDaemon: %v", err)
+	}
+	t.Cleanup(func() { _ = daemon.Stop() })
+
+	for i := 0; i < 5; i++ {
+		name := fmt.Sprintf("User%d", i)
+		res, err := daemon.Call(context.Background(), "greet", map[string]any{"name": name})
+		if err != nil {
+			t.Fatalf("Call %d: %v", i, err)
+		}
+		got := res.(map[string]any)
+		want := "Hello, " + name + "!"
+		if got["greeting"] != want {
+			t.Errorf("call %d: greeting = %v, want %s", i, got["greeting"], want)
+		}
+	}
+}
+
+func TestDaemonToolRef_ImplementsInterface(t *testing.T) {
+	binPath := buildTestDaemon(t)
+
+	daemon, err := StartDaemon(context.Background(), binPath)
+	if err != nil {
+		t.Fatalf("StartDaemon: %v", err)
+	}
+	t.Cleanup(func() { _ = daemon.Stop() })
+
+	defs := daemon.Defs()
+	if len(defs) == 0 {
+		t.Fatal("no defs")
+	}
+
+	ref := NewDaemonToolRef(daemon, defs[0])
+
+	if ref.Name() != "greet" {
+		t.Errorf("Name() = %q", ref.Name())
+	}
+	if ref.Description() != "returns a greeting" {
+		t.Errorf("Description() = %q", ref.Description())
+	}
+
+	td := ref.Definition()
+	if td.Name != "greet" {
+		t.Errorf("Definition().Name = %q", td.Name)
+	}
+
+	result, err := ref.Execute(context.Background(), map[string]any{"name": "Ref"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	got := result.(map[string]any)
+	if got["greeting"] != "Hello, Ref!" {
+		t.Errorf("greeting = %v", got["greeting"])
+	}
+}
+
+func TestDaemonTool_Stop(t *testing.T) {
+	binPath := buildTestDaemon(t)
+
+	daemon, err := StartDaemon(context.Background(), binPath)
+	if err != nil {
+		t.Fatalf("StartDaemon: %v", err)
+	}
+
+	if err := daemon.Stop(); err != nil {
+		// A non-zero exit is fine (stdin closed causes scanner to return).
+		t.Logf("Stop returned: %v (may be expected)", err)
+	}
+}
+

--- a/internal/plugins/tool_exec.go
+++ b/internal/plugins/tool_exec.go
@@ -1,0 +1,135 @@
+package plugins
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/GoCodeAlone/workflow-plugin-agent/provider"
+)
+
+// ToolDef is the on-disk format for a tool's tool.json definition file.
+type ToolDef struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Parameters  map[string]any `json:"parameters"`
+	Protocol    string         `json:"protocol"` // "exec" or "daemon"
+}
+
+// ExecTool implements plugin.Tool by spawning a new process for each call.
+// The binary receives JSON-encoded arguments on stdin and must write a JSON
+// result to stdout.
+type ExecTool struct {
+	def     ToolDef
+	binPath string
+}
+
+// LoadExecTool reads tool.json from toolDir and locates the binary.
+// The binary must be an executable file inside toolDir named after the tool.
+func LoadExecTool(toolDir string) (*ExecTool, error) {
+	defPath := filepath.Join(toolDir, "tool.json")
+	data, err := os.ReadFile(defPath)
+	if err != nil {
+		return nil, fmt.Errorf("read tool.json: %w", err)
+	}
+	var def ToolDef
+	if err := json.Unmarshal(data, &def); err != nil {
+		return nil, fmt.Errorf("parse tool.json: %w", err)
+	}
+	if def.Name == "" {
+		return nil, fmt.Errorf("tool.json: name is required")
+	}
+
+	// Find binary: prefer <toolDir>/<name>, then any executable in toolDir.
+	binPath, err := findBinary(toolDir, def.Name)
+	if err != nil {
+		return nil, err
+	}
+	return &ExecTool{def: def, binPath: binPath}, nil
+}
+
+// findBinary looks for an executable in dir, preferring one named after name.
+func findBinary(dir, name string) (string, error) {
+	preferred := filepath.Join(dir, name)
+	if isExecutable(preferred) {
+		return preferred, nil
+	}
+	// Fall back: scan dir for any executable file.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", fmt.Errorf("scan tool dir: %w", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || e.Name() == "tool.json" {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if info.Mode()&0111 != 0 {
+			return filepath.Join(dir, e.Name()), nil
+		}
+	}
+	return "", fmt.Errorf("no executable binary found in %s", dir)
+}
+
+func isExecutable(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir() && info.Mode()&0111 != 0
+}
+
+// Name implements plugin.Tool.
+func (t *ExecTool) Name() string { return t.def.Name }
+
+// Description implements plugin.Tool.
+func (t *ExecTool) Description() string { return t.def.Description }
+
+// Definition implements plugin.Tool.
+func (t *ExecTool) Definition() provider.ToolDef {
+	return provider.ToolDef{
+		Name:        t.def.Name,
+		Description: t.def.Description,
+		Parameters:  t.def.Parameters,
+	}
+}
+
+// Execute implements plugin.Tool. It marshals args to JSON, writes to stdin,
+// and parses the binary's stdout as JSON.
+func (t *ExecTool) Execute(ctx context.Context, args map[string]any) (any, error) {
+	input, err := json.Marshal(map[string]any{"name": t.def.Name, "arguments": args})
+	if err != nil {
+		return nil, fmt.Errorf("marshal args: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, t.binPath)
+	cmd.Stdin = bytes.NewReader(input)
+
+	out, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if ok := isExitError(err, &exitErr); ok {
+			return nil, fmt.Errorf("tool %s exited with error: %w\nstderr: %s", t.def.Name, err, exitErr.Stderr)
+		}
+		return nil, fmt.Errorf("run tool %s: %w", t.def.Name, err)
+	}
+
+	var result any
+	if err := json.Unmarshal(out, &result); err != nil {
+		return nil, fmt.Errorf("parse tool output: %w", err)
+	}
+	return result, nil
+}
+
+// isExitError checks if err is an *exec.ExitError and extracts it.
+func isExitError(err error, target **exec.ExitError) bool {
+	if ee, ok := err.(*exec.ExitError); ok {
+		*target = ee
+		return true
+	}
+	return false
+}

--- a/internal/plugins/tool_exec_test.go
+++ b/internal/plugins/tool_exec_test.go
@@ -1,0 +1,154 @@
+package plugins
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestExecTool_RoundTrip(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script tools not supported on Windows")
+	}
+	dir := t.TempDir()
+
+	// Write tool.json.
+	def := ToolDef{
+		Name:        "echo_tool",
+		Description: "echoes its arguments",
+		Protocol:    "exec",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"msg": map[string]any{"type": "string"},
+			},
+		},
+	}
+	defData, _ := json.Marshal(def)
+	if err := os.WriteFile(filepath.Join(dir, "tool.json"), defData, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a shell script that echoes stdin back as JSON.
+	script := "#!/bin/sh\ncat\n"
+	binPath := filepath.Join(dir, "echo_tool")
+	if err := os.WriteFile(binPath, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	tool, err := LoadExecTool(dir)
+	if err != nil {
+		t.Fatalf("LoadExecTool: %v", err)
+	}
+
+	if tool.Name() != "echo_tool" {
+		t.Errorf("Name() = %q, want %q", tool.Name(), "echo_tool")
+	}
+	if tool.Description() != "echoes its arguments" {
+		t.Errorf("Description() = %q", tool.Description())
+	}
+
+	args := map[string]any{"msg": "hello"}
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// The binary echoes the envelope {"name":"echo_tool","arguments":{...}}.
+	got, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type = %T, want map[string]any", result)
+	}
+	if got["name"] != "echo_tool" {
+		t.Errorf("result[name] = %v, want echo_tool", got["name"])
+	}
+	arguments, ok := got["arguments"].(map[string]any)
+	if !ok {
+		t.Fatalf("result[arguments] type = %T", got["arguments"])
+	}
+	if arguments["msg"] != "hello" {
+		t.Errorf("arguments[msg] = %v, want hello", arguments["msg"])
+	}
+}
+
+func TestExecTool_MissingBinary(t *testing.T) {
+	dir := t.TempDir()
+
+	def := ToolDef{Name: "no_bin", Protocol: "exec"}
+	defData, _ := json.Marshal(def)
+	_ = os.WriteFile(filepath.Join(dir, "tool.json"), defData, 0644)
+
+	_, err := LoadExecTool(dir)
+	if err == nil {
+		t.Fatal("expected error for missing binary")
+	}
+}
+
+func TestExecTool_MissingToolJSON(t *testing.T) {
+	dir := t.TempDir()
+	_, err := LoadExecTool(dir)
+	if err == nil {
+		t.Fatal("expected error for missing tool.json")
+	}
+}
+
+func TestExecTool_Definition(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script tools not supported on Windows")
+	}
+	dir := t.TempDir()
+
+	params := map[string]any{"type": "object"}
+	def := ToolDef{
+		Name:        "test_tool",
+		Description: "a test",
+		Protocol:    "exec",
+		Parameters:  params,
+	}
+	defData, _ := json.Marshal(def)
+	_ = os.WriteFile(filepath.Join(dir, "tool.json"), defData, 0644)
+	_ = os.WriteFile(filepath.Join(dir, "test_tool"), []byte("#!/bin/sh\necho '{}'"), 0755)
+
+	tool, err := LoadExecTool(dir)
+	if err != nil {
+		t.Fatalf("LoadExecTool: %v", err)
+	}
+
+	td := tool.Definition()
+	if td.Name != "test_tool" {
+		t.Errorf("Definition().Name = %q", td.Name)
+	}
+	if td.Description != "a test" {
+		t.Errorf("Definition().Description = %q", td.Description)
+	}
+}
+
+func TestExecTool_ContextCancellation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script tools not supported on Windows")
+	}
+	dir := t.TempDir()
+
+	def := ToolDef{Name: "slow_tool", Protocol: "exec"}
+	defData, _ := json.Marshal(def)
+	_ = os.WriteFile(filepath.Join(dir, "tool.json"), defData, 0644)
+
+	// Sleep forever script.
+	_ = os.WriteFile(filepath.Join(dir, "slow_tool"), []byte("#!/bin/sh\nsleep 60\n"), 0755)
+
+	tool, err := LoadExecTool(dir)
+	if err != nil {
+		t.Fatalf("LoadExecTool: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err = tool.Execute(ctx, nil)
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+}

--- a/internal/tui/pages/onboarding.go
+++ b/internal/tui/pages/onboarding.go
@@ -1036,17 +1036,28 @@ func (m OnboardingModel) View(t theme.Theme, width, height int) string {
 
 	case stepEnterBaseURL:
 		p := m.selectedProvider()
-		fmt.Fprintf(&sb, "Enter the %s server URL:\n\n", p.displayName)
-		sb.WriteString("URL: " + m.baseURLInput.View() + "\n\n")
 		if p.name == "ollama" {
-			sb.WriteString(mutedStyle.Render("Supports any OpenAI-compatible local server") + "\n")
-			sb.WriteString(mutedStyle.Render("(Ollama, LM Studio, vLLM, llama.cpp)") + "\n\n")
+			sb.WriteString("Local model server URL:\n\n")
+			sb.WriteString("URL: " + m.baseURLInput.View() + "\n\n")
+			sb.WriteString(mutedStyle.Render("The default (http://localhost:11434) works for Ollama.") + "\n")
+			sb.WriteString(mutedStyle.Render("LM Studio, vLLM, and llama.cpp also work — enter their URL.") + "\n\n")
+			sb.WriteString(mutedStyle.Render("Don't have a local model server yet?") + "\n")
+			sb.WriteString(mutedStyle.Render("Run: ratchet provider setup ollama") + "\n")
+			sb.WriteString(mutedStyle.Render("It will install Ollama, download a model, and set everything up.") + "\n\n")
+			sb.WriteString(mutedStyle.Render("Enter: continue  Esc: back"))
+		} else {
+			fmt.Fprintf(&sb, "Enter the %s server URL:\n\n", p.displayName)
+			sb.WriteString("URL: " + m.baseURLInput.View() + "\n\n")
+			sb.WriteString(mutedStyle.Render("Enter: continue  Esc: back"))
 		}
-		sb.WriteString(mutedStyle.Render("Enter: continue  Esc: back"))
 
 	case stepFetchModels:
 		p := m.selectedProvider()
-		sb.WriteString(successStyle.Render("Authenticated!") + "\n\n")
+		if p.auth != authNone {
+			sb.WriteString(successStyle.Render("Authenticated!") + "\n\n")
+		} else {
+			sb.WriteString(successStyle.Render("Connected!") + "\n\n")
+		}
 		sb.WriteString(m.spinner.View() + " Loading available models from " + p.displayName + "...\n\n")
 		sb.WriteString(mutedStyle.Render("Esc: cancel"))
 
@@ -1091,6 +1102,11 @@ func (m OnboardingModel) View(t theme.Theme, width, height int) string {
 			sb.WriteString(errorStyle.Render("Could not fetch models") + "\n\n")
 			if m.modelsError != "" {
 				sb.WriteString(mutedStyle.Render(m.modelsError) + "\n\n")
+			}
+			if m.selectedProvider().name == "ollama" {
+				sb.WriteString(mutedStyle.Render("Is your local model server running?") + "\n")
+				sb.WriteString(mutedStyle.Render("To set up Ollama from scratch, run:") + "\n")
+				sb.WriteString(mutedStyle.Render("  ratchet provider setup ollama") + "\n\n")
 			}
 			sb.WriteString(mutedStyle.Render("Esc: back"))
 		} else {


### PR DESCRIPTION
This pull request introduces a comprehensive implementation plan and detailed design document for completing all remaining unimplemented features and stubs in `ratchet-cli`. The changes lay out the steps, architecture, and testing strategy needed to ensure the codebase is fully functional, with no dead code or placeholders. The plan covers new and updated RPCs, session broadcasting, mesh networking, model switching, error handling improvements, dead code cleanup, and a full suite of tests.

The most important changes are:

**Design and Implementation Planning:**

* Added `docs/plans/2026-04-05-complete-all-gaps-design.md`, a detailed design document specifying the architecture and requirements for implementing all missing features, including shutdown RPC, session attach/detach, agent listing, mesh networking, model switching, improved error handling, dead code cleanup, and a test matrix.
* Added `docs/plans/2026-04-05-complete-all-gaps.md`, an actionable implementation plan breaking down the work into concrete tasks, file changes, code snippets, build/test steps, and commit messages for each feature area.

**Plugin Command Improvements:**

* Enhanced the `plugin` command in `cmd/ratchet/cmd_plugin.go` to support local and GitHub plugin installation, improved listing output (showing name, version, source), and replaced `Remove` with `Uninstall` for consistency. Added an `isLocalPath` helper for path detection. [[1]](diffhunk://#diff-6e6f537425d8ca6db2e291ea54b93e26e86daf607866bd3de9364be7fbdbe80dR4-R7) [[2]](diffhunk://#diff-6e6f537425d8ca6db2e291ea54b93e26e86daf607866bd3de9364be7fbdbe80dL17-R54) [[3]](diffhunk://#diff-6e6f537425d8ca6db2e291ea54b93e26e86daf607866bd3de9364be7fbdbe80dR63-R87)

These documents and code changes collectively provide a clear roadmap and technical foundation for ensuring `ratchet-cli` is robust, fully implemented, and well-tested.