### PR TITLE
ci: publish GoReleaser drafts after artifact upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,3 +21,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      - name: Publish GitHub release
+        if: ${{ success() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ github.ref_name }}" --draft=false --repo "${{ github.repository }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       - name: Publish GitHub release
-        if: ${{ success() }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "${{ github.ref_name }}" --draft=false --repo "${{ github.repository }}"
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.RELEASES_TOKEN || github.token }}
+          script: |
+            const tag = context.ref.replace('refs/tags/', '');
+            const { owner, repo } = context.repo;
+            const { data: release } = await github.rest.repos.getReleaseByTag({ owner, repo, tag });
+            if (release.draft) {
+              await github.rest.repos.updateRelease({
+                owner,
+                repo,
+                release_id: release.id,
+                draft: false,
+              });
+            }

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -58,3 +58,6 @@ brews:
       if OS.mac?
         system "codesign", "--force", "--sign", "-", "#{bin}/ratchet"
       end
+
+release:
+  draft: true

--- a/cmd/ratchet/cmd_provider.go
+++ b/cmd/ratchet/cmd_provider.go
@@ -101,8 +101,9 @@ func handleProvider(args []string) {
 						choice := strings.TrimSpace(scanner.Text())
 						idx := 0
 						if choice != "" {
-							fmt.Sscanf(choice, "%d", &idx)
-							idx-- // 1-indexed
+							if _, scanErr := fmt.Sscanf(choice, "%d", &idx); scanErr == nil {
+								idx-- // 1-indexed
+							}
 						}
 						if idx >= 0 && idx < len(models) {
 							model = models[idx].ID

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -33,7 +33,9 @@ func WriteMCPConfig(path, serverName string, entry MCPServerEntry) error {
 
 	var config ClaudeCodeMCPConfig
 	if data, err := os.ReadFile(path); err == nil {
-		json.Unmarshal(data, &config)
+		if err := json.Unmarshal(data, &config); err != nil {
+			return fmt.Errorf("parse config: %w", err)
+		}
 	}
 	if config.MCPServers == nil {
 		config.MCPServers = make(map[string]MCPServerEntry)
@@ -51,7 +53,9 @@ func WriteCopilotMCPConfig(path, serverName string, entry MCPServerEntry) error 
 
 	var config CopilotMCPConfig
 	if data, err := os.ReadFile(path); err == nil {
-		json.Unmarshal(data, &config)
+		if err := json.Unmarshal(data, &config); err != nil {
+			return fmt.Errorf("parse config: %w", err)
+		}
 	}
 	if config.Servers == nil {
 		config.Servers = make(map[string]MCPServerEntry)

--- a/internal/mesh/bb_bridge.go
+++ b/internal/mesh/bb_bridge.go
@@ -49,9 +49,9 @@ func (b *BBBridge) FormatPrompt(msg Message) string {
 
 	// Team context.
 	sb.WriteString("[TEAM CONTEXT]\n")
-	sb.WriteString(fmt.Sprintf("You are %q (%s role) in a multi-agent team.\n", b.agentName, b.role))
-	sb.WriteString(fmt.Sprintf("The orchestrator is directing you. Other team members: %s\n\n",
-		strings.Join(b.teamMembers, ", ")))
+	fmt.Fprintf(&sb, "You are %q (%s role) in a multi-agent team.\n", b.agentName, b.role)
+	fmt.Fprintf(&sb, "The orchestrator is directing you. Other team members: %s\n\n",
+		strings.Join(b.teamMembers, ", "))
 
 	// Inject relevant BB sections.
 	for _, section := range b.bb.ListSections() {
@@ -64,14 +64,14 @@ func (b *BBBridge) FormatPrompt(msg Message) string {
 		for k, e := range entries {
 			if k != "_init" {
 				if !hasReal {
-					sb.WriteString(fmt.Sprintf("[BLACKBOARD — %s]\n", section))
+					fmt.Fprintf(&sb, "[BLACKBOARD — %s]\n", section)
 					hasReal = true
 				}
 				v := fmt.Sprintf("%v", e.Value)
 				if len(v) > 2000 {
 					v = v[:2000] + "...(truncated)"
 				}
-				sb.WriteString(fmt.Sprintf("%s: %s\n", k, v))
+				fmt.Fprintf(&sb, "%s: %s\n", k, v)
 			}
 		}
 		if hasReal {
@@ -80,7 +80,7 @@ func (b *BBBridge) FormatPrompt(msg Message) string {
 	}
 
 	// Task.
-	sb.WriteString(fmt.Sprintf("[TASK FROM %s]\n", msg.From))
+	fmt.Fprintf(&sb, "[TASK FROM %s]\n", msg.From)
 	sb.WriteString(msg.Content)
 	sb.WriteString("\n\nWhen done, end your response with [RESULT: <one-line summary>].\n")
 


### PR DESCRIPTION
## Summary
- configure GoReleaser to keep GitHub releases as drafts while artifacts are uploaded
- publish the draft release only after the release workflow completes artifact/registry steps
- keep release workflows compatible with GitHub immutable releases

## Verification
- actionlint on changed GoReleaser release workflow
- git diff --check
